### PR TITLE
Bugfix : RandomSecret is not refreshed with refreshPeriod set

### DIFF
--- a/controllers/randomsecret_controller.go
+++ b/controllers/randomsecret_controller.go
@@ -136,7 +136,7 @@ func (r *RandomSecretReconciler) manageCleanUpLogic(context context.Context, ins
 
 func (r *RandomSecretReconciler) manageReconcileLogic(context context.Context, instance *redhatcopv1alpha1.RandomSecret) error {
 	// how to read this if: if the secret has been initialized once and there no refresh period or time ro refresh has not arrived yet, return.
-	if instance.Status.LastVaultSecretUpdate != nil && (instance.Spec.RefreshPeriod != nil || (instance.Spec.RefreshPeriod != nil && !instance.Status.LastVaultSecretUpdate.Add(instance.Spec.RefreshPeriod.Duration).Before(time.Now()))) {
+	if instance.Status.LastVaultSecretUpdate != nil && (instance.Spec.RefreshPeriod == nil || (instance.Spec.RefreshPeriod != nil && !instance.Status.LastVaultSecretUpdate.Add(instance.Spec.RefreshPeriod.Duration).Before(time.Now()))) {
 		return nil
 	}
 	vaultEndpoint := vaultutils.NewVaultEndpoint(instance)


### PR DESCRIPTION
Hello,

I believe there is a bug here.

Do not generate password (return) if : 

* Password has already been generated :  `instance.Status.LastVaultSecretUpdate != nil`
* AND
  * There is no refresh period  `instance.Spec.RefreshPeriod == nil`  (BUGFIX : was the opposite)
  * OR there is a refresh period which is elapsed : `(instance.Spec.RefreshPeriod != nil && !instance.Status.LastVaultSecretUpdate.Add(instance.Spec.RefreshPeriod.Duration).Before(time.Now())))`
 