### PR TITLE
Add volumes and volumeMounts customization to Helm chart.

### DIFF
--- a/config/helmchart/templates/manager.yaml
+++ b/config/helmchart/templates/manager.yaml
@@ -24,7 +24,7 @@ spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-      {{- end }}   
+      {{- end }}
       containers:
       - args:
         - --secure-listen-address=0.0.0.0:8443
@@ -54,10 +54,13 @@ spec:
         - name: webhook-server-cert
           readOnly: true
           mountPath: /tmp/k8s-webhook-server/serving-certs
+        {{- with .Values.volumeMounts }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.env }}
         env:
-         {{- toYaml . | nindent 8 }}
-        {{- end }}        
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         name: {{ .Chart.Name }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
@@ -89,8 +92,12 @@ spec:
       - name: vault-config-operator-certs
         secret:
           defaultMode: 420
-          secretName: vault-config-operator-certs  
+          secretName: vault-config-operator-certs
       - name: webhook-server-cert
         secret:
           secretName: webhook-server-cert
           defaultMode: 420
+      {{- with .Values.volumes }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+

--- a/config/helmchart/values.yaml.tpl
+++ b/config/helmchart/values.yaml.tpl
@@ -14,6 +14,8 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 env: []
+volumes: []
+volumeMounts: []
 podAnnotations: {}
 
 resources:


### PR DESCRIPTION
Additional volumes and volume mounts can be injected using OLM, but the Helm chart does not provide the same functionality. This makes it impossible to specify custom certificates for vault when the operator is installed using the Helm chart.