### PR TITLE
Specify default values for optional usernameKey and passwordKey.

### DIFF
--- a/api/v1alpha1/utils/commons.go
+++ b/api/v1alpha1/utils/commons.go
@@ -190,10 +190,12 @@ type RootCredentialConfig struct {
 
 	// PasswordKey key to be used when retrieving the password, required with VaultSecrets and Kubernetes secrets, ignored with RandomSecret
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default="password"
 	PasswordKey string `json:"passwordKey,omitempty"`
 
 	// UsernameKey key to be used when retrieving the username, optional with VaultSecrets and Kubernetes secrets, ignored with RandomSecret
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default="username"
 	UsernameKey string `json:"usernameKey,omitempty"`
 }
 

--- a/config/crd/bases/redhatcop.redhat.io_databasesecretengineconfigs.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_databasesecretengineconfigs.yaml
@@ -115,6 +115,7 @@ spec:
                   for this DatabaseEngine connection.
                 properties:
                   passwordKey:
+                    default: password
                     description: PasswordKey key to be used when retrieving the password,
                       required with VaultSecrets and Kubernetes secrets, ignored with
                       RandomSecret
@@ -168,6 +169,7 @@ spec:
                         type: string
                     type: object
                   usernameKey:
+                    default: username
                     description: UsernameKey key to be used when retrieving the username,
                       optional with VaultSecrets and Kubernetes secrets, ignored with
                       RandomSecret

--- a/config/crd/bases/redhatcop.redhat.io_jwtoidcauthengineconfigs.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_jwtoidcauthengineconfigs.yaml
@@ -74,6 +74,7 @@ spec:
                   as Kubernetes Secret, VaultSecret or RandomSecret
                 properties:
                   passwordKey:
+                    default: password
                     description: PasswordKey key to be used when retrieving the password,
                       required with VaultSecrets and Kubernetes secrets, ignored with
                       RandomSecret
@@ -127,6 +128,7 @@ spec:
                         type: string
                     type: object
                   usernameKey:
+                    default: username
                     description: UsernameKey key to be used when retrieving the username,
                       optional with VaultSecrets and Kubernetes secrets, ignored with
                       RandomSecret

--- a/config/crd/bases/redhatcop.redhat.io_kubernetessecretengineconfigs.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_kubernetessecretengineconfigs.yaml
@@ -79,6 +79,7 @@ spec:
                   or LocalObjectRefence can be used, random secret is not allowed.
                 properties:
                   passwordKey:
+                    default: password
                     description: PasswordKey key to be used when retrieving the password,
                       required with VaultSecrets and Kubernetes secrets, ignored with
                       RandomSecret
@@ -132,6 +133,7 @@ spec:
                         type: string
                     type: object
                   usernameKey:
+                    default: username
                     description: UsernameKey key to be used when retrieving the username,
                       optional with VaultSecrets and Kubernetes secrets, ignored with
                       RandomSecret

--- a/config/crd/bases/redhatcop.redhat.io_ldapauthengineconfigs.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_ldapauthengineconfigs.yaml
@@ -94,6 +94,7 @@ spec:
                   or RandomSecret
                 properties:
                   passwordKey:
+                    default: password
                     description: PasswordKey key to be used when retrieving the password,
                       required with VaultSecrets and Kubernetes secrets, ignored with
                       RandomSecret
@@ -147,6 +148,7 @@ spec:
                         type: string
                     type: object
                   usernameKey:
+                    default: username
                     description: UsernameKey key to be used when retrieving the username,
                       optional with VaultSecrets and Kubernetes secrets, ignored with
                       RandomSecret

--- a/config/crd/bases/redhatcop.redhat.io_quaysecretengineconfigs.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_quaysecretengineconfigs.yaml
@@ -87,6 +87,7 @@ spec:
                   for this Quay connection.
                 properties:
                   passwordKey:
+                    default: password
                     description: PasswordKey key to be used when retrieving the password,
                       required with VaultSecrets and Kubernetes secrets, ignored with
                       RandomSecret
@@ -140,6 +141,7 @@ spec:
                         type: string
                     type: object
                   usernameKey:
+                    default: username
                     description: UsernameKey key to be used when retrieving the username,
                       optional with VaultSecrets and Kubernetes secrets, ignored with
                       RandomSecret

--- a/config/crd/bases/redhatcop.redhat.io_rabbitmqsecretengineconfigs.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_rabbitmqsecretengineconfigs.yaml
@@ -95,6 +95,7 @@ spec:
                   for this RabbitMQEngine connection.
                 properties:
                   passwordKey:
+                    default: password
                     description: PasswordKey key to be used when retrieving the password,
                       required with VaultSecrets and Kubernetes secrets, ignored with
                       RandomSecret
@@ -148,6 +149,7 @@ spec:
                         type: string
                     type: object
                   usernameKey:
+                    default: username
                     description: UsernameKey key to be used when retrieving the username,
                       optional with VaultSecrets and Kubernetes secrets, ignored with
                       RandomSecret


### PR DESCRIPTION
Without these, at least DatabaseSecretEngineConfig does not work because the operator does not specify a username or password in the request made to Vault for configuring the engine.

Fixes #98