### PR TITLE
Fixes #143

### DIFF
--- a/docs/policy-management.md
+++ b/docs/policy-management.md
@@ -26,7 +26,38 @@ spec:
 ```
 
 Notice that in this policy we have parametrized the path based on the namespace of the connecting service account.
+
 This creates a policy at this path `/sys/policies/acl/<name>`
+
+Automatically resolving an authentication engine accessor into a templated policy HCL can also be achieved for a more declarative style:
+the operator will automatically replace all placeholders with format `${auth/<auth engine path>/@accessor}` with the accessor of the authentication
+engine mounted at path `<auth engine path>`.
+
+See [Vault Templated Policies](https://developer.hashicorp.com/vault/docs/concepts/policies#templated-policies) for more details on templated policies.
+
+Note: the Vault role used for authentication (specified in the `authentication` section) must have `read` and `list` access
+to Vault's `sys/auth` API endpoint for this automated resolution to work.
+
+Any unresolved placeholder is left as-is into the configured policy.
+
+The example above then becomes:
+
+```yaml
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: Policy
+metadata:
+  name: database-creds-reader
+spec:
+  authentication:
+    path: kubernetes
+    role: policy-admin
+  policy: |
+    # Configure read secrets
+    path "/{{identity.entity.aliases.${auth/kubernetes/@accessor}.metadata.service_account_namespace}}/database/creds/+" {
+      capabilities = ["read"]
+    }
+  type: acl
+```
 
 ## PasswordPolicy
 


### PR DESCRIPTION
This implementation aims at automatically resolving Vault auth engine accessors in templated Policies.

This allows to use such templated Policies in a declarative deployment approach without requiring any manual or scripted retrieval of the accessor values (who said gitops?).

Placeholders formatted as `${auth/<auth engine mount>/@accessor}` are replaced with the corresponding value.
This is of course a proposal, and open to discussion!

BTW, it looks like the integration tests would directly benefit from this, as the Kubernetes accessor is retrieved during deployment (see [Makefile@124](https://github.com/redhat-cop/vault-config-operator/blob/main/Makefile#L124)) and used in the test themselves (see [controllers/suite_integration_test.go](https://github.com/redhat-cop/vault-config-operator/blob/main/controllers/suite_integration_test.go#L83) , [controllers/vaultsecret_controller_test.go](https://github.com/redhat-cop/vault-config-operator/blob/main/controllers/vaultsecret_controller_test.go) and [controllers/vaultsecret_controller_v2_test.go](https://github.com/redhat-cop/vault-config-operator/blob/main/controllers/vaultsecret_controller_v2_test.go) ).

Let me know if you want me to have a cut at this as well.
