### PR TITLE
Change condition type back to apis.ReconcileSuccess to fix deletion

### DIFF
--- a/controllers/databasesecretenginestaticrole_controller_test.go
+++ b/controllers/databasesecretenginestaticrole_controller_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/redhat-cop/operator-utils/pkg/util/apis"
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/controllers/databasesecretenginestaticrole_controller_test.go
+++ b/controllers/databasesecretenginestaticrole_controller_test.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
-	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -38,7 +37,7 @@ var _ = Describe("DatabaseSecretEngineStaticRole controller", func() {
 				}
 
 				for _, condition := range pCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -61,7 +60,7 @@ var _ = Describe("DatabaseSecretEngineStaticRole controller", func() {
 				}
 
 				for _, condition := range kaerCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -86,7 +85,7 @@ var _ = Describe("DatabaseSecretEngineStaticRole controller", func() {
 				}
 
 				for _, condition := range semCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -114,7 +113,7 @@ var _ = Describe("DatabaseSecretEngineStaticRole controller", func() {
 				}
 
 				for _, condition := range ppCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -139,7 +138,7 @@ var _ = Describe("DatabaseSecretEngineStaticRole controller", func() {
 				}
 
 				for _, condition := range semCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -165,7 +164,7 @@ var _ = Describe("DatabaseSecretEngineStaticRole controller", func() {
 				}
 
 				for _, condition := range created.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -189,7 +188,7 @@ var _ = Describe("DatabaseSecretEngineStaticRole controller", func() {
 				}
 
 				for _, condition := range rsCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}

--- a/controllers/pkisecretengine_controller_test.go
+++ b/controllers/pkisecretengine_controller_test.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
-	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -38,7 +37,7 @@ var _ = Describe("PKISecretEngineConfig controller", func() {
 				}
 
 				for _, condition := range pCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -61,7 +60,7 @@ var _ = Describe("PKISecretEngineConfig controller", func() {
 				}
 
 				for _, condition := range kaerCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -86,7 +85,7 @@ var _ = Describe("PKISecretEngineConfig controller", func() {
 				}
 
 				for _, condition := range semCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -114,7 +113,7 @@ var _ = Describe("PKISecretEngineConfig controller", func() {
 				}
 
 				for _, condition := range rsCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -142,7 +141,7 @@ var _ = Describe("PKISecretEngineConfig controller", func() {
 				}
 
 				for _, condition := range rsCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}

--- a/controllers/pkisecretengine_controller_test.go
+++ b/controllers/pkisecretengine_controller_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/redhat-cop/operator-utils/pkg/util/apis"
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/controllers/vaultresourcecontroller/utils.go
+++ b/controllers/vaultresourcecontroller/utils.go
@@ -30,8 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-const ReconcileSuccessful = "ReconcileSuccessful"
-
 func ManageOutcomeWithRequeue(context context.Context, r util.ReconcilerBase, obj client.Object, issue error, requeueAfter time.Duration) (reconcile.Result, error) {
 	log := log.FromContext(context)
 	conditionsAware := (obj).(apis.ConditionsAware)
@@ -46,7 +44,7 @@ func ManageOutcomeWithRequeue(context context.Context, r util.ReconcilerBase, ob
 			}
 		}
 		condition = metav1.Condition{
-			Type:               ReconcileSuccessful,
+			Type:               apis.ReconcileSuccess,
 			LastTransitionTime: metav1.Now(),
 			ObservedGeneration: obj.GetGeneration(),
 			Reason:             apis.ReconcileSuccessReason,
@@ -55,7 +53,7 @@ func ManageOutcomeWithRequeue(context context.Context, r util.ReconcilerBase, ob
 	} else {
 		r.GetRecorder().Event(obj, "Warning", "ProcessingError", issue.Error())
 		condition = metav1.Condition{
-			Type:               ReconcileSuccessful,
+			Type:               apis.ReconcileSuccess,
 			LastTransitionTime: metav1.Now(),
 			ObservedGeneration: obj.GetGeneration(),
 			Message:            issue.Error(),

--- a/controllers/vaultsecret_controller_test.go
+++ b/controllers/vaultsecret_controller_test.go
@@ -13,8 +13,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/redhat-cop/operator-utils/pkg/util/apis"
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
-	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/vaultsecret_controller_test.go
+++ b/controllers/vaultsecret_controller_test.go
@@ -44,7 +44,7 @@ var _ = Describe("VaultSecret controller", func() {
 				}
 
 				for _, condition := range ppCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -70,7 +70,7 @@ var _ = Describe("VaultSecret controller", func() {
 				}
 
 				for _, condition := range pCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -95,7 +95,7 @@ var _ = Describe("VaultSecret controller", func() {
 				}
 
 				for _, condition := range pCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -120,7 +120,7 @@ var _ = Describe("VaultSecret controller", func() {
 				}
 
 				for _, condition := range pCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -145,7 +145,7 @@ var _ = Describe("VaultSecret controller", func() {
 				}
 
 				for _, condition := range kaerCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -168,7 +168,7 @@ var _ = Describe("VaultSecret controller", func() {
 				}
 
 				for _, condition := range kaerCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -191,7 +191,7 @@ var _ = Describe("VaultSecret controller", func() {
 				}
 
 				for _, condition := range kaerCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -216,7 +216,7 @@ var _ = Describe("VaultSecret controller", func() {
 				}
 
 				for _, condition := range semCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -241,7 +241,7 @@ var _ = Describe("VaultSecret controller", func() {
 				}
 
 				for _, condition := range rsCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -264,7 +264,7 @@ var _ = Describe("VaultSecret controller", func() {
 				}
 
 				for _, condition := range rsCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -292,7 +292,7 @@ var _ = Describe("VaultSecret controller", func() {
 				}
 
 				for _, condition := range created.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}

--- a/controllers/vaultsecret_controller_v2_test.go
+++ b/controllers/vaultsecret_controller_v2_test.go
@@ -14,8 +14,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
-	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -44,7 +42,7 @@ var _ = Describe("VaultSecret controller for v2 secrets", func() {
 				}
 
 				for _, condition := range ppCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -70,7 +68,7 @@ var _ = Describe("VaultSecret controller for v2 secrets", func() {
 				}
 
 				for _, condition := range pCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -95,7 +93,7 @@ var _ = Describe("VaultSecret controller for v2 secrets", func() {
 				}
 
 				for _, condition := range pCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -120,7 +118,7 @@ var _ = Describe("VaultSecret controller for v2 secrets", func() {
 				}
 
 				for _, condition := range pCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -145,7 +143,7 @@ var _ = Describe("VaultSecret controller for v2 secrets", func() {
 				}
 
 				for _, condition := range kaerCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -168,7 +166,7 @@ var _ = Describe("VaultSecret controller for v2 secrets", func() {
 				}
 
 				for _, condition := range kaerCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -191,7 +189,7 @@ var _ = Describe("VaultSecret controller for v2 secrets", func() {
 				}
 
 				for _, condition := range kaerCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -216,7 +214,7 @@ var _ = Describe("VaultSecret controller for v2 secrets", func() {
 				}
 
 				for _, condition := range semCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -241,7 +239,7 @@ var _ = Describe("VaultSecret controller for v2 secrets", func() {
 				}
 
 				for _, condition := range rsCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -264,7 +262,7 @@ var _ = Describe("VaultSecret controller for v2 secrets", func() {
 				}
 
 				for _, condition := range rsCreated.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -292,7 +290,7 @@ var _ = Describe("VaultSecret controller for v2 secrets", func() {
 				}
 
 				for _, condition := range created.Status.Conditions {
-					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+					if condition.Type == apis.ReconcileSuccess && condition.Status == metav1.ConditionTrue {
 						return true
 					}
 				}

--- a/controllers/vaultsecret_controller_v2_test.go
+++ b/controllers/vaultsecret_controller_v2_test.go
@@ -13,6 +13,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/redhat-cop/operator-utils/pkg/util/apis"
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
It looks like a change was made that changed the status for success from a type of "ReconcileSuccess" to "ReconcileSuccessful". This means that the code (manageCleanUpLogic) that performs a delete wasn't recognizing that the configuration was successfully applied and therefore wouldn't delete configuration from vault.

I have changed it back to use the redhat operator utils "apis.ReconcileSuccess" so that its applied consistently throughout the project. Deletion works afterwards.