### PR TITLE
avoid nil pointer dereference in RandomSecret processing

### DIFF
--- a/api/v1alpha1/randomsecret_types.go
+++ b/api/v1alpha1/randomsecret_types.go
@@ -212,8 +212,12 @@ func (d *RandomSecret) GenerateNewPassword(context context.Context) error {
 			if response == nil || response.Data == nil {
 				return errors.New("no data returned by password policy")
 			}
-			d.Spec.calculatedSecret = response.Data["password"].(string)
-			return nil
+			if password, ok := response.Data["password"]; ok {
+				d.Spec.calculatedSecret = password.(string)
+				return nil
+			} else {
+				return errors.New("password policy did not generate a password")
+			}
 		}
 	}
 	return errors.New("no password policy method specified")

--- a/api/v1alpha1/randomsecret_types.go
+++ b/api/v1alpha1/randomsecret_types.go
@@ -209,11 +209,10 @@ func (d *RandomSecret) GenerateNewPassword(context context.Context) error {
 		if err != nil {
 			return err
 		} else {
-			if response.Data != nil {
-				d.Spec.calculatedSecret = response.Data["password"].(string)
-			} else {
+			if response == nil || response.Data == nil {
 				return errors.New("no data returned by password policy")
 			}
+			d.Spec.calculatedSecret = response.Data["password"].(string)
 			return nil
 		}
 	}


### PR DESCRIPTION
Closes #102
Closes #153 

As explained at https://github.com/hashicorp/vault/issues/8361, `vaultClient.Logical().Read` can return `nil` if there is nothing data at the specified path.

To avoid a nil pointer dereference, we need to check that `response != nil`.

This PR, in the second commit, adds an additional checks to ensure that don't mistakenly misbehave if no `password` was returned by Vault.