### PR TITLE
fix(): discard setInternalCredentials when OIDCCredentials is not set

### DIFF
--- a/api/v1alpha1/jwtoidcauthengineconfig_types.go
+++ b/api/v1alpha1/jwtoidcauthengineconfig_types.go
@@ -211,6 +211,11 @@ func (r *JWTOIDCAuthEngineConfig) GetKubeAuthConfiguration() *vaultutils.KubeAut
 }
 
 func (r *JWTOIDCAuthEngineConfig) PrepareInternalValues(context context.Context, object client.Object) error {
+
+	if reflect.DeepEqual(r.Spec.OIDCCredentials, vaultutils.RootCredentialConfig{PasswordKey: "password", UsernameKey: "username"}) {
+		return nil
+	}
+
 	return r.setInternalCredentials(context)
 }
 


### PR DESCRIPTION
fix(): discard setInternalCredentials when OIDCCredentials is not set for JWTOIDCAuthEngineConfig type