### PR TITLE
Make TokenReviewerServiceAccount optional in KubeAuthEngineConfig

### DIFF
--- a/config/crd/bases/redhatcop.redhat.io_kubernetesauthengineconfigs.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_kubernetesauthengineconfigs.yaml
@@ -164,8 +164,6 @@ spec:
                 pattern: ^(?:/?[\w;:@&=\$-\.\+]*)+/?
                 type: string
               tokenReviewerServiceAccount:
-                default:
-                  name: default
                 description: TokenReviewerServiceAccount A service account JWT used
                   to access the TokenReview API to validate other JWTs during login.
                   If not set, the JWT submitted in the login payload will be used


### PR DESCRIPTION
PR to adress issue https://github.com/redhat-cop/vault-config-operator/issues/176

