### PR TITLE
Fix typo in database role revocation statement

### DIFF
--- a/api/v1alpha1/databasesecretenginerole_types.go
+++ b/api/v1alpha1/databasesecretenginerole_types.go
@@ -171,7 +171,7 @@ func (i *DBSERole) toMap() map[string]interface{} {
 	payload["default_ttl"] = i.DefaultTTL
 	payload["max_ttl"] = i.MaxTTL
 	payload["creation_statements"] = i.CreationStatements
-	payload["revocation_statetments"] = i.RevocationStatements
+	payload["revocation_statements"] = i.RevocationStatements
 	payload["rollback_statements"] = i.RollbackStatements
 	payload["renew_statements"] = i.RenewStatements
 	return payload


### PR DESCRIPTION
Hi there,

This currently breaks the revocation statement setting via the operator. 