### PR TITLE
fix(): use apiextensionsv1.JSON istead of map[string]interface{}

### DIFF
--- a/api/v1alpha1/jwtoidcauthengineconfig_types.go
+++ b/api/v1alpha1/jwtoidcauthengineconfig_types.go
@@ -23,6 +23,7 @@ import (
 
 	vaultutils "github.com/redhat-cop/vault-config-operator/api/v1alpha1/utils"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -151,7 +152,7 @@ type JWTOIDCConfig struct {
 	// The options are described in each provider's section in OIDC Provider Setup
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={}
-	ProviderConfig map[string]string `json:"providerConfig,omitempty"`
+	ProviderConfig *apiextensionsv1.JSON `json:"providerConfig,omitempty"`
 
 	// Pass namespace in the OIDC state parameter instead of as a separate query parameter.
 	// With this setting, the allowed redirect URL(s) in Vault and on the provider side should not contain a namespace query parameter.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -24,6 +24,7 @@ package v1alpha1
 import (
 	"github.com/redhat-cop/vault-config-operator/api/v1alpha1/utils"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -1058,10 +1059,8 @@ func (in *JWTOIDCConfig) DeepCopyInto(out *JWTOIDCConfig) {
 	}
 	if in.ProviderConfig != nil {
 		in, out := &in.ProviderConfig, &out.ProviderConfig
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
+		*out = new(apiextensionsv1.JSON)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/config/crd/bases/redhatcop.redhat.io_jwtoidcauthengineconfigs.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_jwtoidcauthengineconfigs.yaml
@@ -292,12 +292,10 @@ spec:
                 pattern: ^(?:/?[\w;:@&=\$-\.\+]*)+/?
                 type: string
               providerConfig:
-                additionalProperties:
-                  type: string
                 description: 'Configuration options for provider-specific handling.
                   Providers with specific handling include: Azure, Google. The options
                   are described in each provider''s section in OIDC Provider Setup'
-                type: object
+                x-kubernetes-preserve-unknown-fields: true
             type: object
           status:
             description: JWTOIDCAuthEngineConfigStatus defines the observed state


### PR DESCRIPTION
following these discussions : 
https://github.com/kubernetes/gengo/issues/138
https://github.com/kubernetes-sigs/controller-tools/issues/287

the data type map[string]interface{} is not allowed by controller-tools, therefore, I had to use apiextensionsv1.JSON instead.