### PR TITLE
Fixes#103

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,7 +298,7 @@ helmchart: helmchart-clean kustomize helm
 	repo=${OPERATOR_NAME} envsubst < ./config/local-development/tilt/env-replace-image.yaml > ./config/local-development/tilt/replace-image.yaml
 	$(KUSTOMIZE) build ./config/helmchart -o ./charts/${OPERATOR_NAME}/templates
 	sed -i 's/release-namespace/{{.Release.Namespace}}/' ./charts/${OPERATOR_NAME}/templates/*.yaml
-	rm ./charts/${OPERATOR_NAME}/templates/v1_namespace_release-namespace.yaml ./charts/${OPERATOR_NAME}/templates/apps_v1_deployment_${OPERATOR_NAME}-controller-manager.yaml
+	rm ./charts/${OPERATOR_NAME}/templates/apps_v1_deployment_${OPERATOR_NAME}-controller-manager.yaml
 	mv ./charts/${OPERATOR_NAME}/templates/apiextensions.k8s.io_v1_customresourcedefinition* ./charts/${OPERATOR_NAME}/crds
 	cp ./config/helmchart/templates/* ./charts/${OPERATOR_NAME}/templates
 	version=${VERSION} envsubst < ./config/helmchart/Chart.yaml.tpl  > ./charts/${OPERATOR_NAME}/Chart.yaml

--- a/api/v1alpha1/utils/commons.go
+++ b/api/v1alpha1/utils/commons.go
@@ -186,9 +186,9 @@ func (kc *KubeAuthConfiguration) getCacheKey(kubeNamespace string) string {
 func (kc *KubeAuthConfiguration) GetVaultClient(context context.Context, kubeNamespace string) (*vault.Client, error) {
 	log := log.FromContext(context)
 
-	var vaultClient *vault.Client;
+	var vaultClient *vault.Client
 
-	if cacheVaultToken, ok := os.LookupEnv("CACHE_VAULT_TOKEN"); !ok || cacheVaultToken == "true" {
+	if cacheVaultToken, ok := os.LookupEnv("CACHE_VAULT_TOKEN"); ok && cacheVaultToken == "true" {
 		vaultClient := vaultClientCache.Get(kc, kubeNamespace)
 		if vaultClient != nil {
 			// Check if the client's token is still valid.
@@ -256,7 +256,7 @@ func (kc *KubeAuthConfiguration) getJWTToken(context context.Context, kubeNamesp
 
 func (kc *KubeAuthConfiguration) createVaultClient(context context.Context, jwt string, namespace string) (*vault.Client, error) {
 	log := log.FromContext(context)
-	log.Info("Creating new client")
+	log.V(1).Info("Creating new client")
 	vaultConnection := context.Value("vaultConnection").(*VaultConnection)
 	var config *vault.Config
 	if vaultConnection != nil {
@@ -289,7 +289,7 @@ func (kc *KubeAuthConfiguration) createVaultClient(context context.Context, jwt 
 	}
 
 	client.SetToken(secret.Auth.ClientToken)
-	if cacheVaultToken, ok := os.LookupEnv("CACHE_VAULT_TOKEN"); !ok || cacheVaultToken == "true" {
+	if cacheVaultToken, ok := os.LookupEnv("CACHE_VAULT_TOKEN"); ok && cacheVaultToken == "true" {
 		go kc.startLifetimeWatcher(client, namespace, secret, log)
 	}
 

--- a/config/local-development/tilt/kustomization.yaml
+++ b/config/local-development/tilt/kustomization.yaml
@@ -5,9 +5,13 @@ namespace: vault-config-operator
 #commonLabels:
 #  someName: someValue
 
-bases:
+resources:
 - ../../default
 - ./service-account.yaml
+
+patchesStrategicMerge:
+- ./remove-namespace.yaml
+- ./replace-image.yaml
 
 
 patchesJson6902:
@@ -29,6 +33,3 @@ patchesJson6902:
     kind: Service
     name: vault-config-operator-webhook-service
   path: ./secret-injection.yaml
-
-patchesStrategicMerge:
-- replace-image.yaml

--- a/config/local-development/tilt/remove-namespace.yaml
+++ b/config/local-development/tilt/remove-namespace.yaml
@@ -1,0 +1,5 @@
+$patch: delete
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vault-config-operator

--- a/config/local-development/tilt/secret-injection.yaml
+++ b/config/local-development/tilt/secret-injection.yaml
@@ -2,3 +2,6 @@
   path: /metadata/annotations
   value:
     service.alpha.openshift.io/serving-cert-secret-name: webhook-server-cert
+- op: replace
+  path: /metadata/name
+  value: webhook-service    

--- a/controllers/authenginemount_controller.go
+++ b/controllers/authenginemount_controller.go
@@ -21,6 +21,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -71,6 +72,7 @@ func (r *AuthEngineMountReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
+	r.Log.Info("reconcile cycle starting for ", "instance", instance)
 	ctx1, err := prepareContext(ctx, r.ReconcilerBase, instance)
 	if err != nil {
 		r.Log.Error(err, "unable to prepare context", "instance", instance)
@@ -83,6 +85,6 @@ func (r *AuthEngineMountReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 // SetupWithManager sets up the controller with the Manager.
 func (r *AuthEngineMountReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.AuthEngineMount{}).
+		For(&redhatcopv1alpha1.AuthEngineMount{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/controllers/databasesecretengineconfig_controller.go
+++ b/controllers/databasesecretengineconfig_controller.go
@@ -215,7 +215,7 @@ func (r *DatabaseSecretEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.DatabaseSecretEngineConfig{}).
+		For(&redhatcopv1alpha1.DatabaseSecretEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
 		Watches(&source.Kind{Type: &corev1.Secret{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "Secret",

--- a/controllers/databasesecretenginerole_controller.go
+++ b/controllers/databasesecretenginerole_controller.go
@@ -21,6 +21,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -83,6 +84,6 @@ func (r *DatabaseSecretEngineRoleReconciler) Reconcile(ctx context.Context, req 
 // SetupWithManager sets up the controller with the Manager.
 func (r *DatabaseSecretEngineRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.DatabaseSecretEngineRole{}).
+		For(&redhatcopv1alpha1.DatabaseSecretEngineRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/controllers/databasesecretenginestaticrole_controller.go
+++ b/controllers/databasesecretenginestaticrole_controller.go
@@ -21,6 +21,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -74,6 +75,6 @@ func (r *DatabaseSecretEngineStaticRoleReconciler) Reconcile(ctx context.Context
 // SetupWithManager sets up the controller with the Manager.
 func (r *DatabaseSecretEngineStaticRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.DatabaseSecretEngineStaticRole{}).
+		For(&redhatcopv1alpha1.DatabaseSecretEngineStaticRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/controllers/githubsecretengineconfig_controller.go
+++ b/controllers/githubsecretengineconfig_controller.go
@@ -123,7 +123,7 @@ func (r *GitHubSecretEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager) 
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.GitHubSecretEngineConfig{}).
+		For(&redhatcopv1alpha1.GitHubSecretEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
 		Watches(&source.Kind{Type: &corev1.Secret{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "Secret",

--- a/controllers/githubsecretenginerole_controller.go
+++ b/controllers/githubsecretenginerole_controller.go
@@ -21,6 +21,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -83,6 +84,6 @@ func (r *GitHubSecretEngineRoleReconciler) Reconcile(ctx context.Context, req ct
 // SetupWithManager sets up the controller with the Manager.
 func (r *GitHubSecretEngineRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.GitHubSecretEngineRole{}).
+		For(&redhatcopv1alpha1.GitHubSecretEngineRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/controllers/jwtoidcauthengineconfig_controller.go
+++ b/controllers/jwtoidcauthengineconfig_controller.go
@@ -147,7 +147,7 @@ func (r *JWTOIDCAuthEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager) e
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.JWTOIDCAuthEngineConfig{}).
+		For(&redhatcopv1alpha1.JWTOIDCAuthEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
 		Watches(&source.Kind{Type: &corev1.Secret{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "Secret",

--- a/controllers/jwtoidcauthenginerole_controller.go
+++ b/controllers/jwtoidcauthenginerole_controller.go
@@ -21,6 +21,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -78,6 +79,6 @@ func (r *JWTOIDCAuthEngineRoleReconciler) Reconcile(ctx context.Context, req ctr
 // SetupWithManager sets up the controller with the Manager.
 func (r *JWTOIDCAuthEngineRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.JWTOIDCAuthEngineRole{}).
+		For(&redhatcopv1alpha1.JWTOIDCAuthEngineRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/controllers/kubernetesauthengineconfig_controller.go
+++ b/controllers/kubernetesauthengineconfig_controller.go
@@ -21,6 +21,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -87,6 +88,6 @@ func (r *KubernetesAuthEngineConfigReconciler) Reconcile(ctx context.Context, re
 func (r *KubernetesAuthEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.KubernetesAuthEngineConfig{}).
+		For(&redhatcopv1alpha1.KubernetesAuthEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/controllers/kubernetesauthenginerole_controller.go
+++ b/controllers/kubernetesauthenginerole_controller.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -90,7 +91,7 @@ func (r *KubernetesAuthEngineRoleReconciler) Reconcile(ctx context.Context, req 
 // SetupWithManager sets up the controller with the Manager.
 func (r *KubernetesAuthEngineRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.KubernetesAuthEngineRole{}).
+		For(&redhatcopv1alpha1.KubernetesAuthEngineRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
 		Watches(&source.Kind{Type: &corev1.Namespace{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "Namespace",

--- a/controllers/kubernetessecretengineconfig_controller.go
+++ b/controllers/kubernetessecretengineconfig_controller.go
@@ -117,7 +117,7 @@ func (r *KubernetesSecretEngineConfigReconciler) SetupWithManager(mgr ctrl.Manag
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.KubernetesSecretEngineConfig{}).
+		For(&redhatcopv1alpha1.KubernetesSecretEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
 		Watches(&source.Kind{Type: &corev1.Secret{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "Secret",

--- a/controllers/kubernetessecretenginerole_controller.go
+++ b/controllers/kubernetessecretenginerole_controller.go
@@ -21,6 +21,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -77,6 +78,6 @@ func (r *KubernetesSecretEngineRoleReconciler) Reconcile(ctx context.Context, re
 // SetupWithManager sets up the controller with the Manager.
 func (r *KubernetesSecretEngineRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.KubernetesSecretEngineRole{}).
+		For(&redhatcopv1alpha1.KubernetesSecretEngineRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/controllers/ldapauthengineconfig_controller.go
+++ b/controllers/ldapauthengineconfig_controller.go
@@ -148,7 +148,7 @@ func (r *LDAPAuthEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager) erro
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.LDAPAuthEngineConfig{}).
+		For(&redhatcopv1alpha1.LDAPAuthEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
 		Watches(&source.Kind{Type: &corev1.Secret{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "Secret",

--- a/controllers/ldapauthenginegroup_controller.go
+++ b/controllers/ldapauthenginegroup_controller.go
@@ -21,6 +21,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -78,6 +79,6 @@ func (r *LDAPAuthEngineGroupReconciler) Reconcile(ctx context.Context, req ctrl.
 // SetupWithManager sets up the controller with the Manager.
 func (r *LDAPAuthEngineGroupReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.LDAPAuthEngineGroup{}).
+		For(&redhatcopv1alpha1.LDAPAuthEngineGroup{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/controllers/passwordpolicy_controller.go
+++ b/controllers/passwordpolicy_controller.go
@@ -21,6 +21,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/go-logr/logr"
@@ -80,6 +81,6 @@ func (r *PasswordPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 // SetupWithManager sets up the controller with the Manager.
 func (r *PasswordPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.PasswordPolicy{}).
+		For(&redhatcopv1alpha1.PasswordPolicy{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/controllers/pkisecretengineconfig_controller.go
+++ b/controllers/pkisecretengineconfig_controller.go
@@ -21,6 +21,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -78,6 +79,6 @@ func (r *PKISecretEngineConfigReconciler) Reconcile(ctx context.Context, req ctr
 // SetupWithManager sets up the controller with the Manager.
 func (r *PKISecretEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.PKISecretEngineConfig{}).
+		For(&redhatcopv1alpha1.PKISecretEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/controllers/pkisecretenginerole_controller.go
+++ b/controllers/pkisecretenginerole_controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/redhat-cop/operator-utils/pkg/util"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -78,6 +79,6 @@ func (r *PKISecretEngineRoleReconciler) Reconcile(ctx context.Context, req ctrl.
 // SetupWithManager sets up the controller with the Manager.
 func (r *PKISecretEngineRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.PKISecretEngineRole{}).
+		For(&redhatcopv1alpha1.PKISecretEngineRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/controllers/policy_controller.go
+++ b/controllers/policy_controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -80,6 +81,6 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 // SetupWithManager sets up the controller with the Manager.
 func (r *PolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.Policy{}).
+		For(&redhatcopv1alpha1.Policy{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/controllers/quaysecretengineconfig_controller.go
+++ b/controllers/quaysecretengineconfig_controller.go
@@ -145,7 +145,7 @@ func (r *QuaySecretEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager) er
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.QuaySecretEngineConfig{}).
+		For(&redhatcopv1alpha1.QuaySecretEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
 		Watches(&source.Kind{Type: &corev1.Secret{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "Secret",

--- a/controllers/quaysecretenginerole_controller.go
+++ b/controllers/quaysecretenginerole_controller.go
@@ -21,6 +21,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -75,6 +76,6 @@ func (r *QuaySecretEngineRoleReconciler) Reconcile(ctx context.Context, req ctrl
 // SetupWithManager sets up the controller with the Manager.
 func (r *QuaySecretEngineRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.QuaySecretEngineRole{}).
+		For(&redhatcopv1alpha1.QuaySecretEngineRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/controllers/quaysecretenginestaticrole_controller.go
+++ b/controllers/quaysecretenginestaticrole_controller.go
@@ -21,6 +21,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -74,6 +75,6 @@ func (r *QuaySecretEngineStaticRoleReconciler) Reconcile(ctx context.Context, re
 // SetupWithManager sets up the controller with the Manager.
 func (r *QuaySecretEngineStaticRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.QuaySecretEngineStaticRole{}).
+		For(&redhatcopv1alpha1.QuaySecretEngineStaticRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/controllers/rabbitmqsecretengineconfig_controller.go
+++ b/controllers/rabbitmqsecretengineconfig_controller.go
@@ -130,6 +130,6 @@ func (r *RabbitMQSecretEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.RabbitMQSecretEngineConfig{}, builder.WithPredicates(filter)).
+		For(&redhatcopv1alpha1.RabbitMQSecretEngineConfig{}, builder.WithPredicates(filter, vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/controllers/rabbitmqsecretenginerole_controller.go
+++ b/controllers/rabbitmqsecretenginerole_controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -82,6 +83,6 @@ func (r *RabbitMQSecretEngineRoleReconciler) Reconcile(ctx context.Context, req 
 // SetupWithManager sets up the controller with the Manager.
 func (r *RabbitMQSecretEngineRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.RabbitMQSecretEngineRole{}).
+		For(&redhatcopv1alpha1.RabbitMQSecretEngineRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/controllers/randomsecret_controller.go
+++ b/controllers/randomsecret_controller.go
@@ -193,6 +193,6 @@ func (r *RandomSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.RandomSecret{}, builder.WithPredicates(needsCreation)).
+		For(&redhatcopv1alpha1.RandomSecret{}, builder.WithPredicates(needsCreation, vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/controllers/secretenginemount_controller.go
+++ b/controllers/secretenginemount_controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -81,6 +82,6 @@ func (r *SecretEngineMountReconciler) Reconcile(ctx context.Context, req ctrl.Re
 // SetupWithManager sets up the controller with the Manager.
 func (r *SecretEngineMountReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.SecretEngineMount{}).
+		For(&redhatcopv1alpha1.SecretEngineMount{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/controllers/vaultresourcecontroller/utils.go
+++ b/controllers/vaultresourcecontroller/utils.go
@@ -26,7 +26,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -82,4 +84,23 @@ func ManageOutcome(context context.Context, r util.ReconcilerBase, obj client.Ob
 
 func isValid(obj client.Object) (bool, error) {
 	return obj.(vaultutils.VaultObject).IsValid()
+}
+
+// ResourceGenerationChangedPredicate this predicate will fire an update event when the spec of a resource is changed (controller by ResourceGeneration), or when the finalizers are changed
+type ResourceGenerationChangedPredicate struct {
+	predicate.Funcs
+}
+
+// Update implements default UpdateEvent filter for validating resource version change
+func (ResourceGenerationChangedPredicate) Update(e event.UpdateEvent) bool {
+	if e.ObjectOld == nil {
+		return false
+	}
+	if e.ObjectNew == nil {
+		return false
+	}
+	if e.ObjectNew.GetGeneration() == e.ObjectOld.GetGeneration() {
+		return false
+	}
+	return true
 }

--- a/controllers/vaultresourcecontroller/vaultengineresourcereconciler.go
+++ b/controllers/vaultresourcecontroller/vaultengineresourcereconciler.go
@@ -60,7 +60,8 @@ func (r *VaultEngineResource) manageCleanUpLogic(context context.Context, instan
 
 func (r *VaultEngineResource) Reconcile(ctx context.Context, instance client.Object) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
-
+	log.Info("starting reconcile cycle")
+	log.V(1).Info("reconcile", "instance", instance)
 	if util.IsBeingDeleted(instance) {
 		if !util.HasFinalizer(instance, vaultutils.GetFinalizer(instance)) {
 			return reconcile.Result{}, nil

--- a/controllers/vaultresourcecontroller/vaultpkiengineresourcereconciler.go
+++ b/controllers/vaultresourcecontroller/vaultpkiengineresourcereconciler.go
@@ -60,7 +60,8 @@ func (r *VaultPKIEngineResource) manageCleanUpLogic(context context.Context, ins
 
 func (r *VaultPKIEngineResource) Reconcile(ctx context.Context, instance client.Object) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
-
+	log.Info("starting reconcile cycle")
+	log.V(1).Info("reconcile", "instance", instance)
 	if util.IsBeingDeleted(instance) {
 		log.Info("Delete", "Try to: ", instance)
 

--- a/controllers/vaultresourcecontroller/vaultresourcereconciler.go
+++ b/controllers/vaultresourcecontroller/vaultresourcereconciler.go
@@ -43,7 +43,8 @@ func NewVaultResource(reconcilerBase *util.ReconcilerBase, obj client.Object) *V
 
 func (r *VaultResource) Reconcile(ctx context.Context, instance client.Object) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
-
+	log.Info("starting reconcile cycle")
+	log.V(1).Info("reconcile", "instance", instance)
 	if util.IsBeingDeleted(instance) {
 		if !util.HasFinalizer(instance, vaultutils.GetFinalizer(instance)) {
 			return reconcile.Result{}, nil

--- a/controllers/vaultsecret_controller.go
+++ b/controllers/vaultsecret_controller.go
@@ -459,7 +459,7 @@ func (r *VaultSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.VaultSecret{}, builder.WithPredicates(vaultSecretPredicate)).
+		For(&redhatcopv1alpha1.VaultSecret{}, builder.WithPredicates(vaultSecretPredicate, vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
 		Owns(&corev1.Secret{}, builder.WithPredicates(k8sSecretPredicate)).
 		Complete(r)
 }


### PR DESCRIPTION
@erlisb hello, this should help/fix #103 .
I found that the operator was doing 3 reconcile cycles when a new object was created and two reconcile cycle when an existing object needed to be reconciled (operator start-up for example). In both cases an additional reconcile cycle happens randomly and rarely when a race condition happens.

This fix should bring the number of reconcile cycles down to one when a new object is created and when it needs reconcile. I am not sure this fixes the race condition. It is too random to test.

Can you build from this branch and help testing this?