### PR TITLE
Fix validateKVv2DataInPath always fails

### DIFF
--- a/api/v1alpha1/randomsecret_types.go
+++ b/api/v1alpha1/randomsecret_types.go
@@ -339,7 +339,7 @@ func (d *RandomSecret) GetKubeAuthConfiguration() *vaultutils.KubeAuthConfigurat
 }
 
 func (r *RandomSecret) validateKVv2DataInPath() error {
-	if r.IsKVSecretsEngineV2() && !strings.Contains("/data/", r.GetPath()) {
+	if r.IsKVSecretsEngineV2() && !strings.Contains(r.GetPath(), "/data/") {
 		return errors.New("KVv2 secrets must have /data defined in the path, for example /secret-mount-path/data/path")
 	}
 	return nil


### PR DESCRIPTION
introduced in v0.8.22 (https://github.com/redhat-cop/vault-config-operator/pull/189)