### PR TITLE
Fixes#162

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -118,6 +118,8 @@ Additionally, the operator checks for an environment variable named `CACHE_VAULT
 
 By default, or if the variable is set to any other value, the operator will create a new client with a new token for each request it makes to Vault.
 
+SyncPeriod determines the minimum frequency at which watched resources are reconciled. Set the environment variable named `SYNC_PERIOD_SECONDS` to update the frequency at which watched resources are reconciled. It defaults to 10 hours if unset.
+
 For certificates, the recommended approach is to mount the secret or configmap containing the certificate as described [here](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/subscription-config.md#volumes), and the configure the corresponding variables to point at the files location in the mounted path.
 
 Here is an example:


### PR DESCRIPTION
- Environment variable `SYNC_PERIOD_SECONDS` to update resources sync period; fixes [162](https://github.com/redhat-cop/vault-config-operator/issues/162)