### PR TITLE
Fixes #193 by adding key tracing logs for internal eventing and reconciliation logic

### DIFF
--- a/api/v1alpha1/utils/vaultobject.go
+++ b/api/v1alpha1/utils/vaultobject.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/google/go-cmp/cmp"
 	vault "github.com/hashicorp/vault/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -56,6 +57,7 @@ func (ve *VaultEndpoint) DeleteKVv2IfExists(context context.Context) error {
 	// should match pathToDelete := fmt.Sprintf("%s/metadata/%s", kv.mountPath, secretPath)
 	pathToDelete := strings.Replace(ve.vaultObject.GetPath(), "/data/", "/metadata/", 1)
 
+	log.V(1).Info("deleting resource from Vault", "op", "VaultEndpoint.DeleteKVv2IfExists")
 	_, err := vaultClient.Logical().Delete(pathToDelete)
 	if err != nil {
 		if respErr, ok := err.(*vault.ResponseError); ok {
@@ -71,6 +73,7 @@ func (ve *VaultEndpoint) DeleteKVv2IfExists(context context.Context) error {
 
 func (ve *VaultEndpoint) DeleteIfExists(context context.Context) error {
 	log := log.FromContext(context)
+	log.V(1).Info("deleting resource from Vault", "op", "VaultEndpoint.DeleteIfExists")
 	vaultClient := context.Value("vaultClient").(*vault.Client)
 	_, err := vaultClient.Logical().Delete(ve.vaultObject.GetPath())
 	if err != nil {
@@ -86,21 +89,30 @@ func (ve *VaultEndpoint) DeleteIfExists(context context.Context) error {
 }
 
 func (ve *VaultEndpoint) Create(context context.Context) error {
+	log := log.FromContext(context)
+	log.V(1).Info("creating resource in Vault", "op", "VaultEndpoint.Create")
 	return write(context, ve.vaultObject.GetPath(), ve.vaultObject.GetPayload())
 }
 
 func (ve *VaultEndpoint) CreateOrUpdate(context context.Context) error {
 	log := log.FromContext(context)
+	log.V(1).Info("reading resource from Vault", "op", "VaultEndpoint.CreateOrUpdate")
 	currentPayload, found, err := read(context, ve.vaultObject.GetPath())
 	if err != nil {
 		log.Error(err, "unable to read object at", "path", ve.vaultObject.GetPath())
 		return err
 	}
 	if !found {
+		log.V(1).Info("resource does not exist, creating it in Vault", "op", "VaultEndpoint.CreateOrUpdate")
 		return write(context, ve.vaultObject.GetPath(), ve.vaultObject.GetPayload())
 	} else {
 		if !ve.vaultObject.IsEquivalentToDesiredState(currentPayload) {
-			return write(context, ve.vaultObject.GetPath(), ve.vaultObject.GetPayload())
+			updatedPayload := ve.vaultObject.GetPayload()
+			log.V(1).Info("resource is not in sync, writing to Vault", "op", "VaultEndpoint.CreateOrUpdate",
+				"diff", cmp.Diff(currentPayload, updatedPayload))
+			return write(context, ve.vaultObject.GetPath(), updatedPayload)
+		} else {
+			log.V(1).Info("vault resource is already in sync", "op", "VaultEndpoint.CreateOrUpdate")
 		}
 	}
 	return nil
@@ -123,22 +135,31 @@ func (ve *RabbitMQEngineConfigVaultEndpoint) CreateOrUpdateLease(context context
 	if ve.rabbitMQEngineConfigVaultEndpoint.CheckTTLValuesProvided() {
 		return nil
 	}
+	log.V(1).Info("reading resource from Vault", "op", "RabbitMQEngineConfigVaultEndpoint.CreateOrUpdateLease")
 	currentPayload, found, err := read(context, ve.rabbitMQEngineConfigVaultEndpoint.GetLeasePath())
 	if err != nil {
 		log.Error(err, "unable to read object at", "path", ve.rabbitMQEngineConfigVaultEndpoint.GetLeasePath())
 		return err
 	}
 	if !found {
+		log.V(1).Info("resource does not exist, creating it in Vault", "op", "RabbitMQEngineConfigVaultEndpoint.CreateOrUpdateLease")
 		return write(context, ve.rabbitMQEngineConfigVaultEndpoint.GetLeasePath(), ve.rabbitMQEngineConfigVaultEndpoint.GetLeasePayload())
 	} else {
 		if !ve.rabbitMQEngineConfigVaultEndpoint.IsEquivalentToDesiredState(currentPayload) {
-			return write(context, ve.rabbitMQEngineConfigVaultEndpoint.GetLeasePath(), ve.rabbitMQEngineConfigVaultEndpoint.GetLeasePayload())
+			updatedPayload := ve.rabbitMQEngineConfigVaultEndpoint.GetLeasePayload()
+			log.V(1).Info("resource is not in sync, writing to Vault", "op", "RabbitMQEngineConfigVaultEndpoint.CreateOrUpdateLease",
+				"diff", cmp.Diff(currentPayload, updatedPayload))
+			return write(context, ve.rabbitMQEngineConfigVaultEndpoint.GetLeasePath(), updatedPayload)
+		} else {
+			log.V(1).Info("vault resource is already in sync", "op", "RabbitMQEngineConfigVaultEndpoint.CreateOrUpdateLease")
 		}
 	}
 	return nil
 }
 
 func (ve *RabbitMQEngineConfigVaultEndpoint) Create(context context.Context) error {
+	log := log.FromContext(context)
+	log.V(1).Info("creating resource in Vault", "op", "RabbitMQEngineConfigVaultEndpoint.Create")
 	return write(context, ve.rabbitMQEngineConfigVaultEndpoint.GetPath(), ve.rabbitMQEngineConfigVaultEndpoint.GetPayload())
 }
 

--- a/controllers/databasesecretenginerole_controller.go
+++ b/controllers/databasesecretenginerole_controller.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
+	"github.com/redhat-cop/vault-config-operator/controllers/k8sevt"
 	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
 )
 
@@ -80,6 +81,7 @@ func (r *DatabaseSecretEngineRoleReconciler) Reconcile(ctx context.Context, req 
 // SetupWithManager sets up the controller with the Manager.
 func (r *DatabaseSecretEngineRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.DatabaseSecretEngineRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.DatabaseSecretEngineRole{},
+			builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{}, k8sevt.Log{})).
 		Complete(r)
 }

--- a/controllers/databasesecretenginestaticrole_controller.go
+++ b/controllers/databasesecretenginestaticrole_controller.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
+	"github.com/redhat-cop/vault-config-operator/controllers/k8sevt"
 	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
 )
 
@@ -71,6 +72,7 @@ func (r *DatabaseSecretEngineStaticRoleReconciler) Reconcile(ctx context.Context
 // SetupWithManager sets up the controller with the Manager.
 func (r *DatabaseSecretEngineStaticRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.DatabaseSecretEngineStaticRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.DatabaseSecretEngineStaticRole{},
+			builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{}, k8sevt.Log{})).
 		Complete(r)
 }

--- a/controllers/githubsecretenginerole_controller.go
+++ b/controllers/githubsecretenginerole_controller.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
+	"github.com/redhat-cop/vault-config-operator/controllers/k8sevt"
 	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
 )
 
@@ -80,6 +81,7 @@ func (r *GitHubSecretEngineRoleReconciler) Reconcile(ctx context.Context, req ct
 // SetupWithManager sets up the controller with the Manager.
 func (r *GitHubSecretEngineRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.GitHubSecretEngineRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.GitHubSecretEngineRole{},
+			builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{}, k8sevt.Log{})).
 		Complete(r)
 }

--- a/controllers/group_controller.go
+++ b/controllers/group_controller.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
+	"github.com/redhat-cop/vault-config-operator/controllers/k8sevt"
 	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
 )
 
@@ -77,6 +78,7 @@ func (r *GroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 // SetupWithManager sets up the controller with the Manager.
 func (r *GroupReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.Group{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.Group{},
+			builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{}, k8sevt.Log{})).
 		Complete(r)
 }

--- a/controllers/groupalias_controller.go
+++ b/controllers/groupalias_controller.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
+	"github.com/redhat-cop/vault-config-operator/controllers/k8sevt"
 	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
 )
 
@@ -77,6 +78,7 @@ func (r *GroupAliasReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 // SetupWithManager sets up the controller with the Manager.
 func (r *GroupAliasReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.GroupAlias{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.GroupAlias{},
+			builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{}, k8sevt.Log{})).
 		Complete(r)
 }

--- a/controllers/jwtoidcauthenginerole_controller.go
+++ b/controllers/jwtoidcauthenginerole_controller.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
+	"github.com/redhat-cop/vault-config-operator/controllers/k8sevt"
 	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
 )
 
@@ -75,6 +76,7 @@ func (r *JWTOIDCAuthEngineRoleReconciler) Reconcile(ctx context.Context, req ctr
 // SetupWithManager sets up the controller with the Manager.
 func (r *JWTOIDCAuthEngineRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.JWTOIDCAuthEngineRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.JWTOIDCAuthEngineRole{},
+			builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{}, k8sevt.Log{})).
 		Complete(r)
 }

--- a/controllers/k8sevt/k8sevtlogging.go
+++ b/controllers/k8sevt/k8sevtlogging.go
@@ -1,0 +1,74 @@
+/*
+	Logging capable event handler that mimics handler.EnqueueRequestForObject
+	See "sigs.k8s.io/controller-runtime/pkg/handler"
+*/
+
+package k8sevt
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
+)
+
+// List all types which include unexported fields so that cmp.Diff won't choke on them
+var ignoredUnexportedDuringDiff = cmpopts.IgnoreUnexported(
+	redhatcopv1alpha1.VRole{},
+	redhatcopv1alpha1.DBSEConfig{},
+	redhatcopv1alpha1.GHConfig{},
+	redhatcopv1alpha1.JWTOIDCConfig{},
+	redhatcopv1alpha1.KAECConfig{},
+	redhatcopv1alpha1.KubeSEConfig{},
+	redhatcopv1alpha1.LDAPConfig{},
+	redhatcopv1alpha1.PKIIntermediate{},
+	redhatcopv1alpha1.QuayConfig{},
+	redhatcopv1alpha1.RMQSEConfig{},
+	redhatcopv1alpha1.RandomSecretSpec{},
+	redhatcopv1alpha1.GroupAliasSpec{},
+)
+
+var handlerLog = ctrl.Log.WithName("eventhandler")
+
+type Log struct {
+	predicate.Funcs
+}
+
+func (Log) Update(evt event.UpdateEvent) bool {
+	return LogEventWithDiff("UpdateEvent", evt.ObjectOld, evt.ObjectNew)
+}
+
+func (Log) Create(evt event.CreateEvent) bool {
+	return LogEvent("CreateEvent", evt.Object, evt)
+}
+
+func (Log) Delete(evt event.DeleteEvent) bool {
+	return LogEvent("DeleteEvent", evt.Object, evt)
+}
+
+func (Log) Generic(evt event.GenericEvent) bool {
+	return LogEvent("GenericEvent", evt.Object, evt)
+}
+
+func LogEvent(eventName string, object client.Object, evt interface{}) bool {
+	handlerLog.V(1).Info(eventName+" received", "namespace", object.GetNamespace(), "name", object.GetName(), "event", evt)
+	return true
+}
+
+func LogEventWithDiff(eventName string, objectOld client.Object, objectNew client.Object) bool {
+	if handlerLog.V(1).Enabled() {
+		switch {
+		case objectNew != nil:
+			handlerLog.V(1).Info(eventName+" received", "namespace", objectNew.GetNamespace(), "name", objectNew.GetName(),
+				"diff", cmp.Diff(objectOld, objectNew, ignoredUnexportedDuringDiff))
+		case objectOld != nil:
+			handlerLog.V(1).Info(eventName+" received", "namespace", objectNew.GetNamespace(), "name", objectNew.GetName(),
+				"diff", cmp.Diff(objectOld, objectNew, ignoredUnexportedDuringDiff))
+		}
+	}
+	return true
+}

--- a/controllers/kubernetesauthengineconfig_controller.go
+++ b/controllers/kubernetesauthengineconfig_controller.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
+	"github.com/redhat-cop/vault-config-operator/controllers/k8sevt"
 	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
 )
 
@@ -84,6 +85,7 @@ func (r *KubernetesAuthEngineConfigReconciler) Reconcile(ctx context.Context, re
 func (r *KubernetesAuthEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.KubernetesAuthEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.KubernetesAuthEngineConfig{},
+			builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{}, k8sevt.Log{})).
 		Complete(r)
 }

--- a/controllers/kubernetessecretenginerole_controller.go
+++ b/controllers/kubernetessecretenginerole_controller.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
+	"github.com/redhat-cop/vault-config-operator/controllers/k8sevt"
 	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
 )
 
@@ -74,6 +75,7 @@ func (r *KubernetesSecretEngineRoleReconciler) Reconcile(ctx context.Context, re
 // SetupWithManager sets up the controller with the Manager.
 func (r *KubernetesSecretEngineRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.KubernetesSecretEngineRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.KubernetesSecretEngineRole{},
+			builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{}, k8sevt.Log{})).
 		Complete(r)
 }

--- a/controllers/ldapauthengineconfig_controller.go
+++ b/controllers/ldapauthengineconfig_controller.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
+	"github.com/redhat-cop/vault-config-operator/controllers/k8sevt"
 	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
 )
 
@@ -143,7 +144,8 @@ func (r *LDAPAuthEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager) erro
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.LDAPAuthEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.LDAPAuthEngineConfig{},
+			builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{}, k8sevt.Log{})).
 		Watches(&corev1.Secret{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "Secret",
@@ -151,6 +153,7 @@ func (r *LDAPAuthEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager) erro
 		}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
 			res := []reconcile.Request{}
 			s := a.(*corev1.Secret)
+			r.Log.V(1).Info("fanning event on Secret out to applicable LDAPAuthEngineConfigs", "namespace", s.Namespace, "name", s.Name)
 			dbsecs, err := r.findApplicableLAECForSecret(ctx, s)
 			if err != nil {
 				r.Log.Error(err, "unable to find applicable LDAPAuthEngines for namespace", "namespace", s.Name)
@@ -165,7 +168,8 @@ func (r *LDAPAuthEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager) erro
 				})
 			}
 			return res
-		}), builder.WithPredicates(isBasicAuthSecret)).
+
+		}), builder.WithPredicates(isBasicAuthSecret, k8sevt.Log{})).
 		Watches(&redhatcopv1alpha1.RandomSecret{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "RandomSecret",
@@ -173,6 +177,7 @@ func (r *LDAPAuthEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager) erro
 		}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
 			res := []reconcile.Request{}
 			rs := a.(*redhatcopv1alpha1.RandomSecret)
+			r.Log.V(1).Info("fanning event on RandomSecret out to applicable LDAPAuthEngineConfigs", "namespace", rs.Namespace, "name", rs.Name)
 			dbsecs, err := r.findApplicableLAECForRandomSecret(ctx, rs)
 			if err != nil {
 				r.Log.Error(err, "unable to find applicable LDAPAuthEngines for namespace", "namespace", rs.Name)
@@ -187,7 +192,7 @@ func (r *LDAPAuthEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager) erro
 				})
 			}
 			return res
-		}), builder.WithPredicates(isUpdatedRandomSecret)).
+		}), builder.WithPredicates(isUpdatedRandomSecret, k8sevt.Log{})).
 		Complete(r)
 
 }

--- a/controllers/ldapauthenginegroup_controller.go
+++ b/controllers/ldapauthenginegroup_controller.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
+	"github.com/redhat-cop/vault-config-operator/controllers/k8sevt"
 	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
 )
 
@@ -75,6 +76,7 @@ func (r *LDAPAuthEngineGroupReconciler) Reconcile(ctx context.Context, req ctrl.
 // SetupWithManager sets up the controller with the Manager.
 func (r *LDAPAuthEngineGroupReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.LDAPAuthEngineGroup{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.LDAPAuthEngineGroup{},
+			builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{}, k8sevt.Log{})).
 		Complete(r)
 }

--- a/controllers/passwordpolicy_controller.go
+++ b/controllers/passwordpolicy_controller.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
+	"github.com/redhat-cop/vault-config-operator/controllers/k8sevt"
 	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
 )
 
@@ -77,6 +78,7 @@ func (r *PasswordPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 // SetupWithManager sets up the controller with the Manager.
 func (r *PasswordPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.PasswordPolicy{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.PasswordPolicy{},
+			builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{}, k8sevt.Log{})).
 		Complete(r)
 }

--- a/controllers/pkisecretengineconfig_controller.go
+++ b/controllers/pkisecretengineconfig_controller.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
+	"github.com/redhat-cop/vault-config-operator/controllers/k8sevt"
 	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
 )
 
@@ -75,6 +76,7 @@ func (r *PKISecretEngineConfigReconciler) Reconcile(ctx context.Context, req ctr
 // SetupWithManager sets up the controller with the Manager.
 func (r *PKISecretEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.PKISecretEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.PKISecretEngineConfig{},
+			builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{}, k8sevt.Log{})).
 		Complete(r)
 }

--- a/controllers/pkisecretenginerole_controller.go
+++ b/controllers/pkisecretenginerole_controller.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
+	"github.com/redhat-cop/vault-config-operator/controllers/k8sevt"
 	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
 )
 
@@ -75,6 +76,7 @@ func (r *PKISecretEngineRoleReconciler) Reconcile(ctx context.Context, req ctrl.
 // SetupWithManager sets up the controller with the Manager.
 func (r *PKISecretEngineRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.PKISecretEngineRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.PKISecretEngineRole{},
+			builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{}, k8sevt.Log{})).
 		Complete(r)
 }

--- a/controllers/policy_controller.go
+++ b/controllers/policy_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
+	"github.com/redhat-cop/vault-config-operator/controllers/k8sevt"
 	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -77,6 +78,7 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 // SetupWithManager sets up the controller with the Manager.
 func (r *PolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.Policy{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.Policy{},
+			builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{}, k8sevt.Log{})).
 		Complete(r)
 }

--- a/controllers/quaysecretenginerole_controller.go
+++ b/controllers/quaysecretenginerole_controller.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
+	"github.com/redhat-cop/vault-config-operator/controllers/k8sevt"
 	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
 )
 
@@ -72,6 +73,7 @@ func (r *QuaySecretEngineRoleReconciler) Reconcile(ctx context.Context, req ctrl
 // SetupWithManager sets up the controller with the Manager.
 func (r *QuaySecretEngineRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.QuaySecretEngineRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.QuaySecretEngineRole{},
+			builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{}, k8sevt.Log{})).
 		Complete(r)
 }

--- a/controllers/quaysecretenginestaticrole_controller.go
+++ b/controllers/quaysecretenginestaticrole_controller.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
+	"github.com/redhat-cop/vault-config-operator/controllers/k8sevt"
 	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
 )
 
@@ -71,6 +72,7 @@ func (r *QuaySecretEngineStaticRoleReconciler) Reconcile(ctx context.Context, re
 // SetupWithManager sets up the controller with the Manager.
 func (r *QuaySecretEngineStaticRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.QuaySecretEngineStaticRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.QuaySecretEngineStaticRole{},
+			builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{}, k8sevt.Log{})).
 		Complete(r)
 }

--- a/controllers/rabbitmqsecretengineconfig_controller.go
+++ b/controllers/rabbitmqsecretengineconfig_controller.go
@@ -21,6 +21,7 @@ import (
 
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
 	vaultutils "github.com/redhat-cop/vault-config-operator/api/v1alpha1/utils"
+	"github.com/redhat-cop/vault-config-operator/controllers/k8sevt"
 	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -126,6 +127,7 @@ func (r *RabbitMQSecretEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.RabbitMQSecretEngineConfig{}, builder.WithPredicates(filter, vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.RabbitMQSecretEngineConfig{},
+			builder.WithPredicates(filter, vaultresourcecontroller.ResourceGenerationChangedPredicate{}, k8sevt.Log{})).
 		Complete(r)
 }

--- a/controllers/rabbitmqsecretenginerole_controller.go
+++ b/controllers/rabbitmqsecretenginerole_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
+	"github.com/redhat-cop/vault-config-operator/controllers/k8sevt"
 	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -79,6 +80,7 @@ func (r *RabbitMQSecretEngineRoleReconciler) Reconcile(ctx context.Context, req 
 // SetupWithManager sets up the controller with the Manager.
 func (r *RabbitMQSecretEngineRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.RabbitMQSecretEngineRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.RabbitMQSecretEngineRole{},
+			builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{}, k8sevt.Log{})).
 		Complete(r)
 }

--- a/controllers/randomsecret_controller.go
+++ b/controllers/randomsecret_controller.go
@@ -23,6 +23,7 @@ import (
 
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
 	vaultutils "github.com/redhat-cop/vault-config-operator/api/v1alpha1/utils"
+	"github.com/redhat-cop/vault-config-operator/controllers/k8sevt"
 	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -190,6 +191,7 @@ func (r *RandomSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.RandomSecret{}, builder.WithPredicates(needsCreation, vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.RandomSecret{},
+			builder.WithPredicates(needsCreation, vaultresourcecontroller.ResourceGenerationChangedPredicate{}, k8sevt.Log{})).
 		Complete(r)
 }

--- a/controllers/secretenginemount_controller.go
+++ b/controllers/secretenginemount_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	redhatcopv1alpha1 "github.com/redhat-cop/vault-config-operator/api/v1alpha1"
+	"github.com/redhat-cop/vault-config-operator/controllers/k8sevt"
 	"github.com/redhat-cop/vault-config-operator/controllers/vaultresourcecontroller"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -78,6 +79,7 @@ func (r *SecretEngineMountReconciler) Reconcile(ctx context.Context, req ctrl.Re
 // SetupWithManager sets up the controller with the Manager.
 func (r *SecretEngineMountReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.SecretEngineMount{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.SecretEngineMount{},
+			builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{}, k8sevt.Log{})).
 		Complete(r)
 }

--- a/controllers/vaultresourcecontroller/utils.go
+++ b/controllers/vaultresourcecontroller/utils.go
@@ -133,12 +133,14 @@ func ManageOutcomeWithRequeue(context context.Context, r ReconcilerBase, obj cli
 		}
 	}
 	conditionsAware.SetConditions(vaultutils.AddOrReplaceCondition(condition, conditionsAware.GetConditions()))
+	log.V(1).Info("updating k8s resource status")
 	err := r.GetClient().Status().Update(context, obj)
 	if err != nil {
 		log.Error(err, "unable to update status")
 		return reconcile.Result{}, err
 	}
 	if issue == nil && !controllerutil.ContainsFinalizer(obj, vaultutils.GetFinalizer(obj)) {
+		log.V(1).Info("adding k8s resource finalizer")
 		controllerutil.AddFinalizer(obj, vaultutils.GetFinalizer(obj))
 		// BEWARE: this call *mutates* the object in memory with Kube's response, there *must be invoked last*
 		err := r.GetClient().Update(context, obj)
@@ -147,6 +149,7 @@ func ManageOutcomeWithRequeue(context context.Context, r ReconcilerBase, obj cli
 			return reconcile.Result{}, err
 		}
 	}
+
 	return reconcile.Result{RequeueAfter: requeueAfter}, issue
 }
 

--- a/controllers/vaultresourcecontroller/vaultresourcereconciler.go
+++ b/controllers/vaultresourcecontroller/vaultresourcereconciler.go
@@ -53,6 +53,7 @@ func (r *VaultResource) Reconcile(ctx context.Context, instance client.Object) (
 			log.Error(err, "unable to delete instance", "instance", instance)
 			return ManageOutcome(ctx, *r.reconcilerBase, instance, err)
 		}
+		log.V(1).Info("removing k8s resource finalizer")
 		controllerutil.RemoveFinalizer(instance, vaultutils.GetFinalizer(instance))
 		err = r.reconcilerBase.GetClient().Update(ctx, instance)
 		if err != nil {


### PR DESCRIPTION
This commit add several `debug` logs for better troubleshooting:
* each received Kubernetes event monitored by the manager is now logged (using an additional always-true `Predicate` that logs appropriate details, including a diff between old and new Kubernetes object on Update)
* each read, write and delete operation to Vault is now logged
* drift condition is now logged (Vault resource is in sync or not, with diff details in this case)

## Log examples

These examples use a `DatabaseSecretEngineRole` named `test-evtlogging`

Logs below are redacted to remove details so that the log flow is more obvious.

### Creation
```
debug "CreateEvent received" "namespace":"xyz" "name":"test-evtlogging" "event":{...}
debug "Returning cached client" "controller":"databasesecretenginerole" ...
info  "starting reconcile cycle" "controller":"databasesecretenginerole" ...
debug "reconcile" "controller":"databasesecretenginerole" ...
debug "reading resource from Vault" ... "namespace":"xyz" "name":"test-evtlogging"
            ... "op":"VaultEndpoint.CreateOrUpdate"
debug "resource does not exist, creating it in Vault" ... "name":"test-evtlogging" 
            ... "op":"VaultEndpoint.CreateOrUpdate"
debug "updating k8s resource status" ... "name":"test-evtlogging" ...
debug "adding k8s resource finalizer" ... "name":"test-evtlogging" ...
info  "validate update" "name":"test-evtlogging"
```

### Update

This updates changes the `defaultTTL` field value from `0s` to `60s`:

```
info  "validate update" "name":"test-evtlogging"
debug "UpdateEvent received" "namespace":"xyz" "name":"test-evtlogging" "diff":"<event diff>"
debug "Returning cached client" ... "name":"test-evtlogging" ...
info  "starting reconcile cycle" ... "name":"test-evtlogging" ...
debug "reconcile" ... "name":"test-evtlogging" ...
debug "reading resource from Vault" ... "name":"test-evtlogging" ... "op":"VaultEndpoint.CreateOrUpdate"
debug "resource is not in sync, writing to Vault" ... "name":"test-evtlogging"
       ... "op":"VaultEndpoint.CreateOrUpdate" "diff":"<resource diff>"
debug "updating k8s resource status ... "name":"test-evtlogging" ...
```

`<event diff>` is a JSON-like string, which, once unescaped, shows the changes that happened to the Kubernetes resource which triggered the event.
Example:
```diff
  &v1alpha1.DatabaseSecretEngineRole{
    TypeMeta: {},
    ObjectMeta: v1.ObjectMeta{
      ... // 3 identical fields
      SelfLink:          "",
      UID:               "887c67ce-5c09-449a-bcda-db560b641933",
-     ResourceVersion:   "2001996",
+     ResourceVersion:   "2002033",
-     Generation:        1,
+     Generation:        2,
      CreationTimestamp: {Time: s"2023-09-15 07:32:39 +0000 UTC"},
      ...
      ManagedFields: []v1.ManagedFieldsEntry{
        {Manager: "Go-http-client", Operation: "Update", ...},
        ...
+       {
+         Manager:    "kubectl-edit",
+         Operation:  "Update",
+         APIVersion: "redhatcop.redhat.io/v1alpha1",
+         Time:       s"2023-09-15 07:32:57 +0000 UTC",
+         FieldsType: "FieldsV1",
+         FieldsV1:   s`{"f:spec":{"f:defaultTTL":{}}}`,
+       },
      },
    },
    Spec: v1alpha1.DatabaseSecretEngineRoleSpec{
        ...
-       DefaultTTL:         v1.Duration{},
+       DefaultTTL:         v1.Duration{Duration: s"1m0s"},
        MaxTTL:             {},
        ...
      },
    },
    Status: {...},
  }
```

`<resource diff>` is a JSON-like string, which, once unescaped, shows the difference between the object existing in Vault and what is expected from the Kubernetes resource.
Example:

`<resource diff>` is a JSON-like string, which, once unescaped, shows something like:
```diff
map[string]any{
-   "creation_statements": []any{
-     string(`CREATE ROLE "{{name}}" WITH LOGIN ...`...),
-   },
+   "creation_statements": []string{
+     `CREATE ROLE "{{name}}" WITH LOGIN IN ROLE ...`...,
+   },
-   "credential_type":       string("password"),
    "db_name":               string("the-db-name"),
-   "default_ttl":           s"0",
+   "default_ttl":           v1.Duration{Duration: s"1m0s"},
-   "max_ttl":               s"0",
+   "max_ttl":               v1.Duration{},
-   "renew_statements":      []any{},
+   "renew_statements":      []string(nil),
-   "revocation_statements": []any{string(`DROP ROLE "{{name}}";`)},
+   "revocation_statements": []string{`DROP ROLE "{{name}}";`},
-   "rollback_statements":   []any{},
+   "rollback_statements":   []string(nil),
  }
```

**_Note:_** an unexpected finding with these logs is that **there are Go type differences** when comparing the payload returned by Vault and the payload we expect, sometimes leading to unnecessary writes to Vault (for instance, when resync'ing all resources on operator restart or on schedule).

### Deletion

```
debug "UpdateEvent received" "namespace":"xyz" "name":"test-evtlogging" "diff":"<event diff>"
debug "Returning cached client" ... "name":"test-evtlogging" ...
info  "starting reconcile cycle" ... "name":"test-evtlogging" ...
debug "reconcile" ... "name":"test-evtlogging" ...
debug "deleting resource from Vault" ... "name":"test-evtlogging" ... "op":"VaultEndpoint.DeleteIfExists"
debug "removing k8s resource finalizer" ... "name":"test-evtlogging" ...
info  "validate update" "name":"test-evtlogging"
debug "DeleteEvent received" "namespace":"xyz" "name":"test-evtlogging" "event":{...}
```