### PR TITLE
Changed a few logs with low day-to-day interest to debug level

### DIFF
--- a/api/v1alpha1/policy_types.go
+++ b/api/v1alpha1/policy_types.go
@@ -94,7 +94,7 @@ func (d *Policy) PrepareInternalValues(context context.Context, object client.Ob
 		d.Spec.Policy = strings.ReplaceAll(d.Spec.Policy, placeholder, accessor)
 	}
 
-	log.Info("Auth engine accessor(s) resolved", "policy", d.Spec.Policy)
+	log.V(1).Info("Auth engine accessor(s) resolved", "policy", d.Spec.Policy)
 	return nil
 }
 

--- a/api/v1alpha1/utils/commons.go
+++ b/api/v1alpha1/utils/commons.go
@@ -335,10 +335,10 @@ func (kc *KubeAuthConfiguration) startLifetimeWatcher(client *vault.Client, kube
 				log.Error(err, "error while renewing token")
 			}
 
-			log.Info("Deleting cached client")
+			log.V(1).Info("Deleting cached client")
 			vaultClientCache.Delete(kc, kubeNamespace)
 		case renewal := <-watcher.RenewCh():
-			log.Info(fmt.Sprintf("Successfully renewed token: %#v", renewal))
+			log.V(1).Info(fmt.Sprintf("Successfully renewed token: %#v", renewal))
 		}
 
 	}


### PR DESCRIPTION
A few `info` logs having very to little interest to the users on a daily basis, these are rather troubleshooting traces.

This small PR moves these few logs to the `debug` level instead so that users running with default `info` log level are not bothered with these, and log stays concise and informative.