### PR TITLE
Regenerate CRDs to fix broken name pattern

### DIFF
--- a/config/crd/bases/redhatcop.redhat.io_authenginemounts.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_authenginemounts.yaml
@@ -193,7 +193,7 @@ spec:
               name:
                 description: The name of the obejct created in Vault. If this is specified
                   it takes precedence over {metatada.name}
-                pattern: '''[a-z0-9]([-a-z0-9]*[a-z0-9])?'''
+                pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
                 type: string
               path:
                 description: Path at which this auth engine will be mounted The final

--- a/config/crd/bases/redhatcop.redhat.io_databasesecretengineconfigs.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_databasesecretengineconfigs.yaml
@@ -156,7 +156,7 @@ spec:
               name:
                 description: The name of the obejct created in Vault. If this is specified
                   it takes precedence over {metatada.name}
-                pattern: '''[a-z0-9]([-a-z0-9]*[a-z0-9])?'''
+                pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
                 type: string
               passwordPolicy:
                 description: 'PasswordPolicy The name of the password policy to use

--- a/config/crd/bases/redhatcop.redhat.io_databasesecretengineroles.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_databasesecretengineroles.yaml
@@ -151,7 +151,7 @@ spec:
               name:
                 description: The name of the obejct created in Vault. If this is specified
                   it takes precedence over {metatada.name}
-                pattern: '''[a-z0-9]([-a-z0-9]*[a-z0-9])?'''
+                pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
                 type: string
               path:
                 description: Path at which to create the role. The final path in Vault

--- a/config/crd/bases/redhatcop.redhat.io_databasesecretenginestaticroles.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_databasesecretenginestaticroles.yaml
@@ -136,7 +136,7 @@ spec:
               name:
                 description: The name of the obejct created in Vault. If this is specified
                   it takes precedence over {metatada.name}
-                pattern: '''[a-z0-9]([-a-z0-9]*[a-z0-9])?'''
+                pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
                 type: string
               passwordCredentialConfig:
                 description: PasswordCredentialConfig specifies the configuraiton

--- a/config/crd/bases/redhatcop.redhat.io_githubsecretengineroles.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_githubsecretengineroles.yaml
@@ -130,7 +130,7 @@ spec:
               name:
                 description: The name of the obejct created in Vault. If this is specified
                   it takes precedence over {metatada.name}
-                pattern: '''[a-z0-9]([-a-z0-9]*[a-z0-9])?'''
+                pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
                 type: string
               organizationName:
                 description: OrganizationName the name of the organization with the

--- a/config/crd/bases/redhatcop.redhat.io_groupaliases.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_groupaliases.yaml
@@ -125,7 +125,7 @@ spec:
               name:
                 description: The name of the obejct created in Vault. If this is specified
                   it takes precedence over {metatada.name}
-                pattern: '''[a-z0-9]([-a-z0-9]*[a-z0-9])?'''
+                pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
                 type: string
             type: object
           status:

--- a/config/crd/bases/redhatcop.redhat.io_groups.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_groups.yaml
@@ -141,7 +141,7 @@ spec:
               name:
                 description: The name of the obejct created in Vault. If this is specified
                   it takes precedence over {metatada.name}
-                pattern: '''[a-z0-9]([-a-z0-9]*[a-z0-9])?'''
+                pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
                 type: string
               policies:
                 description: Policies Policies to be tied to the group. kubebuilder:validation:UniqueItems=true

--- a/config/crd/bases/redhatcop.redhat.io_kubernetesauthengineconfigs.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_kubernetesauthengineconfigs.yaml
@@ -159,7 +159,7 @@ spec:
               name:
                 description: The name of the obejct created in Vault. If this is specified
                   it takes precedence over {metatada.name}
-                pattern: '''[a-z0-9]([-a-z0-9]*[a-z0-9])?'''
+                pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
                 type: string
               path:
                 description: Path at which to make the configuration. The final path

--- a/config/crd/bases/redhatcop.redhat.io_kubernetesauthengineroles.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_kubernetesauthengineroles.yaml
@@ -145,7 +145,7 @@ spec:
               name:
                 description: The name of the obejct created in Vault. If this is specified
                   it takes precedence over {metatada.name}
-                pattern: '''[a-z0-9]([-a-z0-9]*[a-z0-9])?'''
+                pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
                 type: string
               path:
                 description: Path at which to make the configuration. The final path

--- a/config/crd/bases/redhatcop.redhat.io_kubernetessecretengineroles.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_kubernetessecretengineroles.yaml
@@ -183,7 +183,7 @@ spec:
               name:
                 description: The name of the obejct created in Vault. If this is specified
                   it takes precedence over {metatada.name}
-                pattern: '''[a-z0-9]([-a-z0-9]*[a-z0-9])?'''
+                pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
                 type: string
               nameTemplate:
                 description: NameTemplate The name template to use when generating

--- a/config/crd/bases/redhatcop.redhat.io_passwordpolicies.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_passwordpolicies.yaml
@@ -121,7 +121,7 @@ spec:
               name:
                 description: The name of the obejct created in Vault. If this is specified
                   it takes precedence over {metatada.name}
-                pattern: '''[a-z0-9]([-a-z0-9]*[a-z0-9])?'''
+                pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
                 type: string
               passwordPolicy:
                 description: PasswordPolicy  is a Vault password policy (https://www.vaultproject.io/docs/concepts/password-policies)

--- a/config/crd/bases/redhatcop.redhat.io_pkisecretengineroles.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_pkisecretengineroles.yaml
@@ -301,7 +301,7 @@ spec:
               name:
                 description: The name of the obejct created in Vault. If this is specified
                   it takes precedence over {metatada.name}
-                pattern: '''[a-z0-9]([-a-z0-9]*[a-z0-9])?'''
+                pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
                 type: string
               noStore:
                 description: If set, certificates issued/signed against this role

--- a/config/crd/bases/redhatcop.redhat.io_policies.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_policies.yaml
@@ -121,7 +121,7 @@ spec:
               name:
                 description: The name of the obejct created in Vault. If this is specified
                   it takes precedence over {metatada.name}
-                pattern: '''[a-z0-9]([-a-z0-9]*[a-z0-9])?'''
+                pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
                 type: string
               policy:
                 description: Policy is a Vault policy expressed in HCL language.

--- a/config/crd/bases/redhatcop.redhat.io_quaysecretengineroles.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_quaysecretengineroles.yaml
@@ -140,7 +140,7 @@ spec:
               name:
                 description: The name of the obejct created in Vault. If this is specified
                   it takes precedence over {metatada.name}
-                pattern: '''[a-z0-9]([-a-z0-9]*[a-z0-9])?'''
+                pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
                 type: string
               namespaceName:
                 description: NamespaceName Name of the Quay account.

--- a/config/crd/bases/redhatcop.redhat.io_quaysecretenginestaticroles.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_quaysecretenginestaticroles.yaml
@@ -135,7 +135,7 @@ spec:
               name:
                 description: The name of the obejct created in Vault. If this is specified
                   it takes precedence over {metatada.name}
-                pattern: '''[a-z0-9]([-a-z0-9]*[a-z0-9])?'''
+                pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
                 type: string
               namespaceName:
                 description: NamespaceName Name of the Quay account.

--- a/config/crd/bases/redhatcop.redhat.io_rabbitmqsecretengineroles.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_rabbitmqsecretengineroles.yaml
@@ -123,7 +123,7 @@ spec:
               name:
                 description: The name of the obejct created in Vault. If this is specified
                   it takes precedence over {metatada.name}
-                pattern: '''[a-z0-9]([-a-z0-9]*[a-z0-9])?'''
+                pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
                 type: string
               path:
                 description: Path at which to make the configuration. The final path

--- a/config/crd/bases/redhatcop.redhat.io_randomsecrets.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_randomsecrets.yaml
@@ -127,7 +127,7 @@ spec:
               name:
                 description: The name of the obejct created in Vault. If this is specified
                   it takes precedence over {metatada.name}
-                pattern: '''[a-z0-9]([-a-z0-9]*[a-z0-9])?'''
+                pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
                 type: string
               path:
                 description: Path at which to create the secret. The final path in

--- a/config/crd/bases/redhatcop.redhat.io_secretenginemounts.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_secretenginemounts.yaml
@@ -191,7 +191,7 @@ spec:
               name:
                 description: The name of the obejct created in Vault. If this is specified
                   it takes precedence over {metatada.name}
-                pattern: '''[a-z0-9]([-a-z0-9]*[a-z0-9])?'''
+                pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
                 type: string
               options:
                 additionalProperties:


### PR DESCRIPTION
During #202 (specifically cc426f8b94869fc4ce4e8e1dff6d7382752b3b70) the quoting of the validation patterns for the new `name` field was fixed, but it was missed to regenerate the CRDs, which I have done with this PR. Currently the validation does not work correctly when applying as-is from e.g. helm because of this.