### PR TITLE
FIX #230 CRD passwordAuthentication for PostgreSQL Database Secret Engine Configs

### DIFF
--- a/config/crd/bases/redhatcop.redhat.io_databasesecretengineconfigs.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_databasesecretengineconfigs.yaml
@@ -158,6 +158,17 @@ spec:
                   it takes precedence over {metatada.name}
                 pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
                 type: string
+              passwordAuthentication:
+                description: When set to "scram-sha-256", passwords will be hashed
+                  by Vault and stored as-is by PostgreSQL. Using "scram-sha-256" requires
+                  a minimum version of PostgreSQL 10. Available options are "scram-sha-256"
+                  and "password". The default is "password". When set to "password",
+                  passwords will be sent to PostgreSQL in plaintext format and may
+                  appear in PostgreSQL logs as-is.
+                enum:
+                - password
+                - scram-sha-256
+                type: string
               passwordPolicy:
                 description: 'PasswordPolicy The name of the password policy to use
                   when generating passwords for this database. If not specified, this

--- a/docs/secret-engines.md
+++ b/docs/secret-engines.md
@@ -72,6 +72,7 @@ spec:
   rootPasswordRotation:
     enable: true
     rotationPeriod: 2m  
+  passwordAuthentication: scram-sha-256
 ```
 
 The `pluginName` field specifies what type of database this connection is for.
@@ -87,6 +88,8 @@ The `path` field specifies the path of the secret engine to which this connectio
 The `rootPasswordRotation.enable` field activates the root password rotation. The root password wil be rotated immediately. It is recommended to use this feature with care as there is no way to recover the root password. 
 
 The `rootPasswordRotation.rotationPeriod` field tells the operator to periodically rotate the root password. If only enable is specified the password will be rotated only once.
+
+The `passwordAuthentication` field, set to `scram-sha-256`, tells Vault to hash the password before sending it to PostgreSQL. This field is optional; if not specified, the default value is "password". When set to "password", passwords are sent to PostgreSQL in clear text and may appear as such in PostgreSQL logs.
 
 The password and possibly the username can be retrived a three different ways:
 


### PR DESCRIPTION
Hello,

Here's a proposal for using the passwordAuthentication option with the value scram-sha-256
Thanks

Gauthier