### PR TITLE
fix(): fix datatype for CRD spec.BoundClaims

### DIFF
--- a/api/v1alpha1/jwtoidcauthenginerole_types.go
+++ b/api/v1alpha1/jwtoidcauthenginerole_types.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 
 	vaultutils "github.com/redhat-cop/vault-config-operator/api/v1alpha1/utils"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -105,7 +106,7 @@ type JWTOIDCRole struct {
 	// Keys support JSON pointer syntax for referencing claims
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={}
-	BoundClaims map[string]string `json:"boundClaims,omitempty"`
+	BoundClaims *apiextensionsv1.JSON `json:"boundClaims,omitempty"`
 
 	// Configures the interpretation of the bound_claims values.
 	// If "string" (the default), the values will treated as string literals and must match exactly.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1342,10 +1342,8 @@ func (in *JWTOIDCRole) DeepCopyInto(out *JWTOIDCRole) {
 	}
 	if in.BoundClaims != nil {
 		in, out := &in.BoundClaims, &out.BoundClaims
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
+		*out = new(apiextensionsv1.JSON)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ClaimMappings != nil {
 		in, out := &in.ClaimMappings, &out.ClaimMappings

--- a/config/crd/bases/redhatcop.redhat.io_jwtoidcauthengineroles.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_jwtoidcauthengineroles.yaml
@@ -90,14 +90,12 @@ spec:
                 type: array
                 x-kubernetes-list-type: set
               boundClaims:
-                additionalProperties:
-                  type: string
                 description: If set, a map of claims (keys) to match against respective
                   claim values (values) The expected value may be a single string
                   or a list of strings The interpretation of the bound claim values
                   is configured with bound_claims_type Keys support JSON pointer syntax
                   for referencing claims
-                type: object
+                x-kubernetes-preserve-unknown-fields: true
               boundClaimsType:
                 default: string
                 description: Configures the interpretation of the bound_claims values.


### PR DESCRIPTION
As mentioned here: https://github.com/redhat-cop/vault-config-operator/issues/232, there is mismatch between Vault API and _JWTOIDCAuthEngineRole_ CRD schema for the _BoundClaims_ field, therefore I had to use _apiextensionsv1.JSON_ as a datatype instead.