### PR TITLE
passwordAuthentication for PostgreSQL Database Secret Engine Configs (rewrite of https://github.com/redhat-cop/vault-config-operator/pull/235)

### DIFF
--- a/api/v1alpha1/databasesecretengineconfig_types.go
+++ b/api/v1alpha1/databasesecretengineconfig_types.go
@@ -237,6 +237,12 @@ type DBSEConfig struct {
 	// kubebuilder:validation:UniqueItems=true
 	RootRotationStatements []string `json:"rootRotationStatements,omitempty"`
 
+	// PasswordAuthentication When set to "scram-sha-256", passwords will be hashed by Vault and stored as-is by PostgreSQL. Using "scram-sha-256" requires a minimum version of PostgreSQL 10. Available options are "scram-sha-256" and "password". The default is "password". When set to "password", passwords will be sent to PostgreSQL in plaintext format and may appear in PostgreSQL logs as-is.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum:={"password","scram-sha-256"}
+	// +kubebuilder:default:="password"
+	PasswordAuthentication string `json:"passwordAuthentication,omitempty"`
+
 	// PasswordPolicy The name of the password policy to use when generating passwords for this database. If not specified, this will use a default policy defined as: 20 characters with at least 1 uppercase, 1 lowercase, 1 number, and 1 dash character.
 	// +kubebuilder:validation:Optional
 	PasswordPolicy string `json:"passwordPolicy,omitempty"`

--- a/docs/secret-engines.md
+++ b/docs/secret-engines.md
@@ -95,6 +95,8 @@ The password and possibly the username can be retrived a three different ways:
 2. From a Vault secret, specifying the `rootCredentialsFromVaultSecret` field.
 3. From a [RandomSecret](#RandomSecret), specifying the `rootCredentialsFromRandomSecret` field. When the RandomSecret generates a new secret, this connection will also be updated.
 
+The `passwordAuthentication` field, set to `scram-sha-256`, tells Vault to hash the password before sending it to PostgreSQL. This field is optional; if not specified, the default value is "password". When set to "password", passwords are sent to PostgreSQL in clear text and may appear as such in PostgreSQL logs.
+
 Many other standard Database Secret Engine Config fields are available for fine tuning, see the [Vault Documentation](https://www.vaultproject.io/api-docs/secret/databases#configure-connection)
 
 This CR is roughly equivalent to this Vault CLI command:


### PR DESCRIPTION
Here's a proposal to use passwordAuthentication option when creating Postgres databaseSecretEngineConfig.

Possible values : 
- password (default)
- scram-sha-256
