### PR TITLE
Revert "#196 RandomSecret retention policy attribute and logic Including one-off existing Vault secret overwrite protection"

### DIFF
--- a/api/v1alpha1/randomsecret_types.go
+++ b/api/v1alpha1/randomsecret_types.go
@@ -80,19 +80,9 @@ type RandomSecretSpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Pattern:=`[a-z0-9]([-a-z0-9]*[a-z0-9])?`
 	Name string `json:"name,omitempty"`
-
-	// The KV secret retain policy to apply when the Kubernetes resource is deleted.
-	// When unspecified, the KV secret is also deleted.
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Enum:={"Delete","Retain"}
-	// +kubebuilder:default:="Delete"
-	KvSecretRetainPolicy string `json:"kvSecretRetainPolicy,omitempty"`
 }
 
 const ttlKey string = "ttl"
-
-const RetainKvSecretRetainPolicy = "Retain"
-const DeleteKvSecretRetainPolicy = "Delete"
 
 var _ vaultutils.VaultObject = &RandomSecret{}
 var _ vaultutils.ConditionsAware = &RandomSecret{}

--- a/api/v1alpha1/utils/vaultobject.go
+++ b/api/v1alpha1/utils/vaultobject.go
@@ -87,16 +87,6 @@ func (ve *VaultEndpoint) DeleteIfExists(context context.Context) error {
 	return nil
 }
 
-func (ve *VaultEndpoint) Exists(context context.Context) (bool, error) {
-	log := log.FromContext(context)
-	_, found, err := read(context, ve.vaultObject.GetPath())
-	if err != nil {
-		log.Error(err, "unable to check object existence at", "path", ve.vaultObject.GetPath())
-		return false, err
-	}
-	return found, nil
-}
-
 func (ve *VaultEndpoint) Create(context context.Context) error {
 	return write(context, ve.vaultObject.GetPath(), ve.vaultObject.GetPayload())
 }

--- a/config/crd/bases/redhatcop.redhat.io_randomsecrets.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_randomsecrets.yaml
@@ -124,14 +124,6 @@ spec:
                   is V2 or not. Default is false to indicate the payload to send is
                   for KV Secret Engine V1.
                 type: boolean
-              kvSecretRetainPolicy:
-                default: Delete
-                description: The KV secret retain policy to apply when the Kubernetes
-                  resource is deleted. When unspecified, the KV secret is also deleted.
-                enum:
-                - Delete
-                - Retain
-                type: string
               name:
                 description: The name of the obejct created in Vault. If this is specified
                   it takes precedence over {metatada.name}

--- a/controllers/randomsecret_controller.go
+++ b/controllers/randomsecret_controller.go
@@ -123,10 +123,6 @@ func (r *RandomSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request
 }
 
 func (r *RandomSecretReconciler) manageCleanUpLogic(context context.Context, instance *redhatcopv1alpha1.RandomSecret) error {
-	if instance.Spec.KvSecretRetainPolicy == redhatcopv1alpha1.RetainKvSecretRetainPolicy {
-		return nil
-	}
-
 	vaultEndpoint := vaultutils.NewVaultEndpoint(instance)
 
 	if instance.IsKVSecretsEngineV2() {
@@ -151,19 +147,6 @@ func (r *RandomSecretReconciler) manageReconcileLogic(context context.Context, i
 		return nil
 	}
 	vaultEndpoint := vaultutils.NewVaultEndpoint(instance)
-	// When this is a newly created RandomSecret and no refresh period is defined (= one-off random password)
-	// check that the Vault KV secret does not exist already to avoid overwriting its existing value.
-	if instance.Status.LastVaultSecretUpdate == nil && instance.Spec.RefreshPeriod == nil {
-		found, err := vaultEndpoint.Exists(context)
-		if err != nil {
-			r.Log.Error(err, "unable to verify secret existence", "instance", instance)
-			return err
-		}
-		if found {
-			r.Log.Info("no refresh period is defined and Vault secret already exists - nothing to do", "name", instance.Name)
-			return nil
-		}
-	}
 	err := instance.PrepareInternalValues(context, instance)
 	if err != nil {
 		r.Log.Error(err, "unable to generate new secret", "instance", instance)

--- a/docs/secret-management.md
+++ b/docs/secret-management.md
@@ -43,24 +43,6 @@ This CR is roughly equivalent to this Vault CLI command:
 vault kv put [namespace/]kv/vault-tenant password=<generated value>
 ```
 
-### Retention policy on delete
-
-Since v0.8.17, when a `RandomSecret` Kubernetes resource is deleted, then the corresponding KV secret is also entirely deleted
-from Vault (all versions of it when using using KVv2).
-
-Since v0.8.30, this can be controlled using the optional `spec.kvSecretRetainPolicy` attribute,
-which possible values are `Delete` (default) or `Retain`.
-
-When set to `Retain`, then the KV secret is *not* deleted from Vault when the `RandomSecret` resource is deleted: this allows to
-protect randomly-generated but important secrets from unexpected deletion, such as a root password as described above
-(which you don't want to loose if the Kubernetes `RandomSecret` was erroneously deleted).
-
-In addition to this, starting with v0.8.30, when a `RandomSecret` is created without a `refreshPeriod`
-and with a corresponding *existing* Vault secret, this Vault secret will *not* be updated:
-this is intended to provide overwrite protection for Kubernetes recreate-after-delete actions
-and again avoid loosing the initially generated secret value.
-
-
 ## VaultSecret
 
 The VaultSecret CRD allows a user to create a K8s Secret from one or more Vault Secrets. It uses go templating to allow formatting of the K8s Secret in the `output.stringData` section of the spec.


### PR DESCRIPTION
Reverts redhat-cop/vault-config-operator#252