### PR TITLE
fix group payload

### DIFF
--- a/api/v1alpha1/group_types.go
+++ b/api/v1alpha1/group_types.go
@@ -148,7 +148,7 @@ func (i *GroupSpec) toMap() map[string]interface{} {
 	payload["metadata"] = i.Metadata
 	payload["policies"] = i.Policies
 	if i.Type == "internal" {
-		payload["member_group_ids"] = i.MemberEntityIDs
+		payload["member_group_ids"] = i.MemberGroupIDs
 		payload["member_entity_ids"] = i.MemberEntityIDs
 	}
 	return payload


### PR DESCRIPTION
There's an error which puts the memberEntityIDs array in the member_group_ids slot of the payload.