### PR TITLE
Create set-vault-env.sh

### DIFF
--- a/hack/set-vault-env.sh
+++ b/hack/set-vault-env.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Script to set environment variables on the Vault Config Operator deployment
+oc set env deployment/vault-config-operator-controller-manager -n vault-config-operator \
+  VAULT_ADDR=http://vault.vault.svc:8200 \
+  VAULT_SKIP_VERIFY=true


### PR DESCRIPTION
Script to set environment variables on the Vault Config Operator deployment. Without it, in a clustered environment, the automation may fail.