### PR TITLE
Fix PKI secret engine role enum validation for string arrays

### DIFF
--- a/api/v1alpha1/pkisecretenginerole_types.go
+++ b/api/v1alpha1/pkisecretenginerole_types.go
@@ -184,17 +184,15 @@ type PKIRole struct {
 
 	// Specifies the allowed key usage constraint on issued certificates. Valid values can be found at https://golang.org/pkg/crypto/x509/#KeyUsage - simply drop the KeyUsage part of the value. Values are not case-sensitive. To specify no key usage constraints, set this to an empty list.
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Enum:=DigitalSignature;KeyAgreement;KeyEncipherment;ContentCommitment;DataEncipherment;CertSign;CRLSign;EncipherOnly;DecipherOnly
 	// +listType=set
 	// kubebuilder:validation:UniqueItems=true
-	KeyUsage []string `json:"keyUsage,omitempty"`
+	KeyUsage []KeyUsage `json:"keyUsage,omitempty"`
 
 	// Specifies the allowed extended key usage constraint on issued certificates. Valid values can be found at https://golang.org/pkg/crypto/x509/#ExtKeyUsage - simply drop the ExtKeyUsage part of the value. Values are not case-sensitive. To specify no key usage constraints, set this to an empty list.
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Enum:=ServerAuth;ClientAuth;CodeSigning;EmailProtection;IPSECEndSystem;IPSECTunnel;IPSECUser;TimeStamping;OCSPSigning;MicrosoftServerGatedCrypto;NetscapeServerGatedCrypto;MicrosoftCommercialCodeSigning;MicrosoftKernelCodeSigning
 	// +listType=set
 	// kubebuilder:validation:UniqueItems=true
-	ExtKeyUsage []string `json:"extKeyUsage,omitempty"`
+	ExtKeyUsage []ExtKeyUsage `json:"extKeyUsage,omitempty"`
 
 	// A comma-separated string or list of extended key usage oids.
 	// +kubebuilder:validation:Optional
@@ -271,6 +269,14 @@ type PKIRole struct {
 	// +kubebuilder:default="30s"
 	NotBeforeDuration metav1.Duration `json:"notBeforeDuration,omitempty"`
 }
+
+// KeyUsage specifies the allowed key usage constraint on issued certificates. Valid values can be found at https://golang.org/pkg/crypto/x509/#KeyUsage - simply drop the KeyUsage part of the value.
+// +kubebuilder:validation:Enum:=DigitalSignature;KeyAgreement;KeyEncipherment;ContentCommitment;DataEncipherment;CertSign;CRLSign;EncipherOnly;DecipherOnly
+type KeyUsage string
+
+// ExtKeyUsage specifies the allowed extended key usage constraint on issued certificates. Valid values can be found at https://golang.org/pkg/crypto/x509/#ExtKeyUsage - simply drop the ExtKeyUsage part of the value.
+// +kubebuilder:validation:Enum:=ServerAuth;ClientAuth;CodeSigning;EmailProtection;IPSECEndSystem;IPSECTunnel;IPSECUser;TimeStamping;OCSPSigning;MicrosoftServerGatedCrypto;NetscapeServerGatedCrypto;MicrosoftCommercialCodeSigning;MicrosoftKernelCodeSigning
+type ExtKeyUsage string
 
 // PKISecretEngineRoleStatus defines the observed state of PKISecretEngineRole
 type PKISecretEngineRoleStatus struct {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -3376,12 +3376,12 @@ func (in *PKIRole) DeepCopyInto(out *PKIRole) {
 	}
 	if in.KeyUsage != nil {
 		in, out := &in.KeyUsage, &out.KeyUsage
-		*out = make([]string, len(*in))
+		*out = make([]KeyUsage, len(*in))
 		copy(*out, *in)
 	}
 	if in.ExtKeyUsage != nil {
 		in, out := &in.ExtKeyUsage, &out.ExtKeyUsage
-		*out = make([]string, len(*in))
+		*out = make([]ExtKeyUsage, len(*in))
 		copy(*out, *in)
 	}
 	if in.ExtKeyUsageOids != nil {

--- a/config/crd/bases/redhatcop.redhat.io_pkisecretengineroles.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_pkisecretengineroles.yaml
@@ -222,21 +222,25 @@ spec:
                 description: |-
                   Specifies the allowed extended key usage constraint on issued certificates. Valid values can be found at https://golang.org/pkg/crypto/x509/#ExtKeyUsage - simply drop the ExtKeyUsage part of the value. Values are not case-sensitive. To specify no key usage constraints, set this to an empty list.
                   kubebuilder:validation:UniqueItems=true
-                enum:
-                - ServerAuth
-                - ClientAuth
-                - CodeSigning
-                - EmailProtection
-                - IPSECEndSystem
-                - IPSECTunnel
-                - IPSECUser
-                - TimeStamping
-                - OCSPSigning
-                - MicrosoftServerGatedCrypto
-                - NetscapeServerGatedCrypto
-                - MicrosoftCommercialCodeSigning
-                - MicrosoftKernelCodeSigning
                 items:
+                  description: ExtKeyUsage specifies the allowed extended key usage
+                    constraint on issued certificates. Valid values can be found at
+                    https://golang.org/pkg/crypto/x509/#ExtKeyUsage - simply drop
+                    the ExtKeyUsage part of the value.
+                  enum:
+                  - ServerAuth
+                  - ClientAuth
+                  - CodeSigning
+                  - EmailProtection
+                  - IPSECEndSystem
+                  - IPSECTunnel
+                  - IPSECUser
+                  - TimeStamping
+                  - OCSPSigning
+                  - MicrosoftServerGatedCrypto
+                  - NetscapeServerGatedCrypto
+                  - MicrosoftCommercialCodeSigning
+                  - MicrosoftKernelCodeSigning
                   type: string
                 type: array
                 x-kubernetes-list-type: set
@@ -277,17 +281,20 @@ spec:
                 description: |-
                   Specifies the allowed key usage constraint on issued certificates. Valid values can be found at https://golang.org/pkg/crypto/x509/#KeyUsage - simply drop the KeyUsage part of the value. Values are not case-sensitive. To specify no key usage constraints, set this to an empty list.
                   kubebuilder:validation:UniqueItems=true
-                enum:
-                - DigitalSignature
-                - KeyAgreement
-                - KeyEncipherment
-                - ContentCommitment
-                - DataEncipherment
-                - CertSign
-                - CRLSign
-                - EncipherOnly
-                - DecipherOnly
                 items:
+                  description: KeyUsage specifies the allowed key usage constraint
+                    on issued certificates. Valid values can be found at https://golang.org/pkg/crypto/x509/#KeyUsage
+                    - simply drop the KeyUsage part of the value.
+                  enum:
+                  - DigitalSignature
+                  - KeyAgreement
+                  - KeyEncipherment
+                  - ContentCommitment
+                  - DataEncipherment
+                  - CertSign
+                  - CRLSign
+                  - EncipherOnly
+                  - DecipherOnly
                   type: string
                 type: array
                 x-kubernetes-list-type: set


### PR DESCRIPTION
Fixes https://github.com/redhat-cop/vault-config-operator/issues/216

When validating a list of strings as an enum in kubebuilder you need to separate it out into its own type. See https://github.com/kubernetes-sigs/kubebuilder/issues/2812 for more details.
