### PR TITLE
Implement configurable drift detection for Vault resources

### DIFF
--- a/controllers/authenginemount_controller.go
+++ b/controllers/authenginemount_controller.go
@@ -81,6 +81,6 @@ func (r *AuthEngineMountReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 // SetupWithManager sets up the controller with the Manager.
 func (r *AuthEngineMountReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.AuthEngineMount{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.AuthEngineMount{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Complete(r)
 }

--- a/controllers/azureauthengineconfig_controller.go
+++ b/controllers/azureauthengineconfig_controller.go
@@ -137,7 +137,7 @@ func (r *AzureAuthEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager) err
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.AzureAuthEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.AzureAuthEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Watches(&corev1.Secret{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "Secret",

--- a/controllers/azureauthenginerole_controller.go
+++ b/controllers/azureauthenginerole_controller.go
@@ -70,6 +70,6 @@ func (r *AzureAuthEngineRoleReconciler) Reconcile(ctx context.Context, req ctrl.
 // SetupWithManager sets up the controller with the Manager.
 func (r *AzureAuthEngineRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.AzureAuthEngineRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.AzureAuthEngineRole{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Complete(r)
 }

--- a/controllers/azuresecretengineconfig_controller.go
+++ b/controllers/azuresecretengineconfig_controller.go
@@ -143,7 +143,7 @@ func (r *AzureSecretEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager) e
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.AzureSecretEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.AzureSecretEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Watches(&corev1.Secret{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "Secret",

--- a/controllers/azuresecretenginerole_controller.go
+++ b/controllers/azuresecretenginerole_controller.go
@@ -69,6 +69,6 @@ func (r *AzureSecretEngineRoleReconciler) Reconcile(ctx context.Context, req ctr
 // SetupWithManager sets up the controller with the Manager.
 func (r *AzureSecretEngineRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.AzureSecretEngineRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.AzureSecretEngineRole{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Complete(r)
 }

--- a/controllers/databasesecretengineconfig_controller.go
+++ b/controllers/databasesecretengineconfig_controller.go
@@ -210,7 +210,7 @@ func (r *DatabaseSecretEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.DatabaseSecretEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.DatabaseSecretEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Watches(&corev1.Secret{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "Secret",

--- a/controllers/databasesecretenginerole_controller.go
+++ b/controllers/databasesecretenginerole_controller.go
@@ -80,6 +80,6 @@ func (r *DatabaseSecretEngineRoleReconciler) Reconcile(ctx context.Context, req 
 // SetupWithManager sets up the controller with the Manager.
 func (r *DatabaseSecretEngineRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.DatabaseSecretEngineRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.DatabaseSecretEngineRole{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Complete(r)
 }

--- a/controllers/databasesecretenginestaticrole_controller.go
+++ b/controllers/databasesecretenginestaticrole_controller.go
@@ -71,6 +71,6 @@ func (r *DatabaseSecretEngineStaticRoleReconciler) Reconcile(ctx context.Context
 // SetupWithManager sets up the controller with the Manager.
 func (r *DatabaseSecretEngineStaticRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.DatabaseSecretEngineStaticRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.DatabaseSecretEngineStaticRole{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Complete(r)
 }

--- a/controllers/gcpauthengineconfig_controller.go
+++ b/controllers/gcpauthengineconfig_controller.go
@@ -138,7 +138,7 @@ func (r *GCPAuthEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager) error
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.GCPAuthEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.GCPAuthEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Watches(&corev1.Secret{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "Secret",

--- a/controllers/githubsecretengineconfig_controller.go
+++ b/controllers/githubsecretengineconfig_controller.go
@@ -118,7 +118,7 @@ func (r *GitHubSecretEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager) 
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.GitHubSecretEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.GitHubSecretEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Watches(&corev1.Secret{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "Secret",

--- a/controllers/githubsecretenginerole_controller.go
+++ b/controllers/githubsecretenginerole_controller.go
@@ -80,6 +80,6 @@ func (r *GitHubSecretEngineRoleReconciler) Reconcile(ctx context.Context, req ct
 // SetupWithManager sets up the controller with the Manager.
 func (r *GitHubSecretEngineRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.GitHubSecretEngineRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.GitHubSecretEngineRole{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Complete(r)
 }

--- a/controllers/group_controller.go
+++ b/controllers/group_controller.go
@@ -77,6 +77,6 @@ func (r *GroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 // SetupWithManager sets up the controller with the Manager.
 func (r *GroupReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.Group{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.Group{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Complete(r)
 }

--- a/controllers/groupalias_controller.go
+++ b/controllers/groupalias_controller.go
@@ -77,6 +77,6 @@ func (r *GroupAliasReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 // SetupWithManager sets up the controller with the Manager.
 func (r *GroupAliasReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.GroupAlias{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.GroupAlias{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Complete(r)
 }

--- a/controllers/jwtoidcauthengineconfig_controller.go
+++ b/controllers/jwtoidcauthengineconfig_controller.go
@@ -142,7 +142,7 @@ func (r *JWTOIDCAuthEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager) e
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.JWTOIDCAuthEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.JWTOIDCAuthEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Watches(&corev1.Secret{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "Secret",

--- a/controllers/jwtoidcauthenginerole_controller.go
+++ b/controllers/jwtoidcauthenginerole_controller.go
@@ -75,6 +75,6 @@ func (r *JWTOIDCAuthEngineRoleReconciler) Reconcile(ctx context.Context, req ctr
 // SetupWithManager sets up the controller with the Manager.
 func (r *JWTOIDCAuthEngineRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.JWTOIDCAuthEngineRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.JWTOIDCAuthEngineRole{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Complete(r)
 }

--- a/controllers/kubernetesauthengineconfig_controller.go
+++ b/controllers/kubernetesauthengineconfig_controller.go
@@ -84,6 +84,6 @@ func (r *KubernetesAuthEngineConfigReconciler) Reconcile(ctx context.Context, re
 func (r *KubernetesAuthEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.KubernetesAuthEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.KubernetesAuthEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Complete(r)
 }

--- a/controllers/kubernetesauthenginerole_controller.go
+++ b/controllers/kubernetesauthenginerole_controller.go
@@ -86,7 +86,7 @@ func (r *KubernetesAuthEngineRoleReconciler) Reconcile(ctx context.Context, req 
 // SetupWithManager sets up the controller with the Manager.
 func (r *KubernetesAuthEngineRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.KubernetesAuthEngineRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.KubernetesAuthEngineRole{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Watches(&corev1.Namespace{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "Namespace",

--- a/controllers/kubernetessecretengineconfig_controller.go
+++ b/controllers/kubernetessecretengineconfig_controller.go
@@ -112,7 +112,7 @@ func (r *KubernetesSecretEngineConfigReconciler) SetupWithManager(mgr ctrl.Manag
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.KubernetesSecretEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.KubernetesSecretEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Watches(&corev1.Secret{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "Secret",

--- a/controllers/kubernetessecretenginerole_controller.go
+++ b/controllers/kubernetessecretenginerole_controller.go
@@ -74,6 +74,6 @@ func (r *KubernetesSecretEngineRoleReconciler) Reconcile(ctx context.Context, re
 // SetupWithManager sets up the controller with the Manager.
 func (r *KubernetesSecretEngineRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.KubernetesSecretEngineRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.KubernetesSecretEngineRole{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Complete(r)
 }

--- a/controllers/ldapauthengineconfig_controller.go
+++ b/controllers/ldapauthengineconfig_controller.go
@@ -172,7 +172,7 @@ func (r *LDAPAuthEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager) erro
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.LDAPAuthEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.LDAPAuthEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Watches(&corev1.Secret{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "Secret",

--- a/controllers/ldapauthenginegroup_controller.go
+++ b/controllers/ldapauthenginegroup_controller.go
@@ -75,6 +75,6 @@ func (r *LDAPAuthEngineGroupReconciler) Reconcile(ctx context.Context, req ctrl.
 // SetupWithManager sets up the controller with the Manager.
 func (r *LDAPAuthEngineGroupReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.LDAPAuthEngineGroup{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.LDAPAuthEngineGroup{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Complete(r)
 }

--- a/controllers/passwordpolicy_controller.go
+++ b/controllers/passwordpolicy_controller.go
@@ -77,6 +77,6 @@ func (r *PasswordPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 // SetupWithManager sets up the controller with the Manager.
 func (r *PasswordPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.PasswordPolicy{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.PasswordPolicy{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Complete(r)
 }

--- a/controllers/pkisecretengineconfig_controller.go
+++ b/controllers/pkisecretengineconfig_controller.go
@@ -75,6 +75,6 @@ func (r *PKISecretEngineConfigReconciler) Reconcile(ctx context.Context, req ctr
 // SetupWithManager sets up the controller with the Manager.
 func (r *PKISecretEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.PKISecretEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.PKISecretEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Complete(r)
 }

--- a/controllers/pkisecretenginerole_controller.go
+++ b/controllers/pkisecretenginerole_controller.go
@@ -75,6 +75,6 @@ func (r *PKISecretEngineRoleReconciler) Reconcile(ctx context.Context, req ctrl.
 // SetupWithManager sets up the controller with the Manager.
 func (r *PKISecretEngineRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.PKISecretEngineRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.PKISecretEngineRole{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Complete(r)
 }

--- a/controllers/policy_controller.go
+++ b/controllers/policy_controller.go
@@ -77,6 +77,6 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 // SetupWithManager sets up the controller with the Manager.
 func (r *PolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.Policy{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.Policy{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Complete(r)
 }

--- a/controllers/quaysecretengineconfig_controller.go
+++ b/controllers/quaysecretengineconfig_controller.go
@@ -140,7 +140,7 @@ func (r *QuaySecretEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager) er
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.QuaySecretEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.QuaySecretEngineConfig{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Watches(&corev1.Secret{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "Secret",

--- a/controllers/quaysecretenginerole_controller.go
+++ b/controllers/quaysecretenginerole_controller.go
@@ -72,6 +72,6 @@ func (r *QuaySecretEngineRoleReconciler) Reconcile(ctx context.Context, req ctrl
 // SetupWithManager sets up the controller with the Manager.
 func (r *QuaySecretEngineRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.QuaySecretEngineRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.QuaySecretEngineRole{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Complete(r)
 }

--- a/controllers/quaysecretenginestaticrole_controller.go
+++ b/controllers/quaysecretenginestaticrole_controller.go
@@ -71,6 +71,6 @@ func (r *QuaySecretEngineStaticRoleReconciler) Reconcile(ctx context.Context, re
 // SetupWithManager sets up the controller with the Manager.
 func (r *QuaySecretEngineStaticRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.QuaySecretEngineStaticRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.QuaySecretEngineStaticRole{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Complete(r)
 }

--- a/controllers/rabbitmqsecretengineconfig_controller.go
+++ b/controllers/rabbitmqsecretengineconfig_controller.go
@@ -126,6 +126,6 @@ func (r *RabbitMQSecretEngineConfigReconciler) SetupWithManager(mgr ctrl.Manager
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.RabbitMQSecretEngineConfig{}, builder.WithPredicates(filter, vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.RabbitMQSecretEngineConfig{}, builder.WithPredicates(filter, vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Complete(r)
 }

--- a/controllers/rabbitmqsecretenginerole_controller.go
+++ b/controllers/rabbitmqsecretenginerole_controller.go
@@ -79,6 +79,6 @@ func (r *RabbitMQSecretEngineRoleReconciler) Reconcile(ctx context.Context, req 
 // SetupWithManager sets up the controller with the Manager.
 func (r *RabbitMQSecretEngineRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.RabbitMQSecretEngineRole{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.RabbitMQSecretEngineRole{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Complete(r)
 }

--- a/controllers/randomsecret_controller.go
+++ b/controllers/randomsecret_controller.go
@@ -207,6 +207,6 @@ func (r *RandomSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.RandomSecret{}, builder.WithPredicates(needsCreation, vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.RandomSecret{}, builder.WithPredicates(needsCreation, vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Complete(r)
 }

--- a/controllers/secretenginemount_controller.go
+++ b/controllers/secretenginemount_controller.go
@@ -78,6 +78,6 @@ func (r *SecretEngineMountReconciler) Reconcile(ctx context.Context, req ctrl.Re
 // SetupWithManager sets up the controller with the Manager.
 func (r *SecretEngineMountReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.SecretEngineMount{}, builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.SecretEngineMount{}, builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Complete(r)
 }

--- a/controllers/vaultresourcecontroller/utils_test.go
+++ b/controllers/vaultresourcecontroller/utils_test.go
@@ -1,0 +1,260 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vaultresourcecontroller
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+// MockConditionsAware is a mock implementation using testify/mock
+type MockConditionsAware struct {
+	mock.Mock
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+}
+
+func (m *MockConditionsAware) GetConditions() []metav1.Condition {
+	args := m.Called()
+	return args.Get(0).([]metav1.Condition)
+}
+
+func (m *MockConditionsAware) SetConditions(conditions []metav1.Condition) {
+	m.Called(conditions)
+}
+
+func (m *MockConditionsAware) GetObjectKind() schema.ObjectKind {
+	return &m.TypeMeta
+}
+
+func (m *MockConditionsAware) DeepCopyObject() runtime.Object {
+	args := m.Called()
+	if obj := args.Get(0); obj != nil {
+		return obj.(runtime.Object)
+	}
+	return nil
+}
+
+func (m *MockConditionsAware) DeepCopyInto(out *MockConditionsAware) {
+	m.Called(out)
+}
+
+// NewMockConditionsAware creates a new mock with common setup
+func NewMockConditionsAware(generation int64, conditions []metav1.Condition) *MockConditionsAware {
+	mock := &MockConditionsAware{
+		ObjectMeta: metav1.ObjectMeta{
+			Generation: generation,
+		},
+	}
+	if conditions != nil {
+		mock.On("GetConditions").Return(conditions)
+	}
+	return mock
+}
+
+func TestIsDriftDetectionEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected bool
+	}{
+		{
+			name:     "Disabled when env var not set",
+			envValue: "",
+			expected: false,
+		},
+		{
+			name:     "Enabled when env var is true",
+			envValue: "true",
+			expected: true,
+		},
+		{
+			name:     "Disabled when env var is false",
+			envValue: "false",
+			expected: false,
+		},
+		{
+			name:     "Disabled when env var is invalid",
+			envValue: "invalid",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up environment
+			if tt.envValue != "" {
+				os.Setenv("ENABLE_DRIFT_DETECTION", tt.envValue)
+			} else {
+				os.Unsetenv("ENABLE_DRIFT_DETECTION")
+			}
+			defer os.Unsetenv("ENABLE_DRIFT_DETECTION")
+
+			result := IsDriftDetectionEnabled()
+			if result != tt.expected {
+				t.Errorf("IsDriftDetectionEnabled() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestPeriodicReconcilePredicate_Update(t *testing.T) {
+	predicate := NewPeriodicReconcilePredicate(5 * time.Minute)
+
+	tests := []struct {
+		name                  string
+		oldGeneration         int64
+		newGeneration         int64
+		conditions            []metav1.Condition
+		driftDetectionEnabled bool
+		expectedResult        bool
+		description           string
+	}{
+		{
+			name:                  "Should reconcile when generation changes regardless of drift detection setting",
+			oldGeneration:         1,
+			newGeneration:         2,
+			conditions:            []metav1.Condition{},
+			driftDetectionEnabled: false,
+			expectedResult:        true,
+			description:           "Generation change should always trigger reconcile",
+		},
+		{
+			name:          "Should reconcile when interval has elapsed and drift detection is enabled",
+			oldGeneration: 1,
+			newGeneration: 1,
+			conditions: []metav1.Condition{
+				{
+					Type:               ReconcileSuccessful,
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(time.Now().Add(-10 * time.Minute)), // 10 minutes ago
+				},
+			},
+			driftDetectionEnabled: true,
+			expectedResult:        true,
+			description:           "Should reconcile when enough time has passed and drift detection is enabled",
+		},
+		{
+			name:          "Should not reconcile when interval has elapsed but drift detection is disabled",
+			oldGeneration: 1,
+			newGeneration: 1,
+			conditions: []metav1.Condition{
+				{
+					Type:               ReconcileSuccessful,
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(time.Now().Add(-10 * time.Minute)), // 10 minutes ago
+				},
+			},
+			driftDetectionEnabled: false,
+			expectedResult:        false,
+			description:           "Should not reconcile when drift detection is disabled even if time has elapsed",
+		},
+		{
+			name:          "Should not reconcile when interval has not elapsed",
+			oldGeneration: 1,
+			newGeneration: 1,
+			conditions: []metav1.Condition{
+				{
+					Type:               ReconcileSuccessful,
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(time.Now().Add(-2 * time.Minute)), // 2 minutes ago
+				},
+			},
+			driftDetectionEnabled: true,
+			expectedResult:        false,
+			description:           "Should not reconcile when not enough time has passed",
+		},
+		{
+			name:          "Should not reconcile when last reconcile failed",
+			oldGeneration: 1,
+			newGeneration: 1,
+			conditions: []metav1.Condition{
+				{
+					Type:               ReconcileFailed,
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.NewTime(time.Now().Add(-10 * time.Minute)),
+				},
+			},
+			driftDetectionEnabled: true,
+			expectedResult:        false,
+			description:           "Should not reconcile based on time when last reconcile failed",
+		},
+		{
+			name:                  "Should not reconcile when no conditions exist and drift detection is enabled",
+			oldGeneration:         1,
+			newGeneration:         1,
+			conditions:            []metav1.Condition{},
+			driftDetectionEnabled: true,
+			expectedResult:        false,
+			description:           "Should not reconcile when no conditions exist",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up drift detection environment
+			if tt.driftDetectionEnabled {
+				os.Setenv("ENABLE_DRIFT_DETECTION", "true")
+			} else {
+				os.Unsetenv("ENABLE_DRIFT_DETECTION")
+			}
+			defer os.Unsetenv("ENABLE_DRIFT_DETECTION")
+
+			// Create mock objects
+			oldObj := &MockConditionsAware{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: tt.oldGeneration,
+				},
+			}
+			newObj := &MockConditionsAware{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: tt.newGeneration,
+				},
+			}
+
+			// Set up mock expectations for GetConditions only when needed
+			// GetConditions is only called when:
+			// 1. Generation hasn't changed AND
+			// 2. Drift detection is enabled
+			if tt.oldGeneration == tt.newGeneration && tt.driftDetectionEnabled {
+				newObj.On("GetConditions").Return(tt.conditions)
+			}
+
+			// Create update event
+			updateEvent := event.UpdateEvent{
+				ObjectOld: oldObj,
+				ObjectNew: newObj,
+			}
+
+			// Test the predicate
+			result := predicate.Update(updateEvent)
+			if result != tt.expectedResult {
+				t.Errorf("%s: expected %v, got %v", tt.description, tt.expectedResult, result)
+			}
+
+			// Assert that all expectations were met
+			newObj.AssertExpectations(t)
+		})
+	}
+}

--- a/controllers/vaultsecret_controller.go
+++ b/controllers/vaultsecret_controller.go
@@ -456,7 +456,7 @@ func (r *VaultSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&redhatcopv1alpha1.VaultSecret{}, builder.WithPredicates(vaultSecretPredicate, vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+		For(&redhatcopv1alpha1.VaultSecret{}, builder.WithPredicates(vaultSecretPredicate, vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
 		Owns(&corev1.Secret{}, builder.WithPredicates(k8sSecretPredicate)).
 		Complete(r)
 }

--- a/docs/contributing-vault-apis.md
+++ b/docs/contributing-vault-apis.md
@@ -109,7 +109,7 @@ Here are the steps:
 
     func (r *MyVaultTypeReconciler) SetupWithManager(mgr ctrl.Manager) error {
       return ctrl.NewControllerManagedBy(mgr).
-        For(&redhatcopv1alpha1.MyVaultType{},builder.WithPredicates(vaultresourcecontroller.ResourceGenerationChangedPredicate{})).
+        For(&redhatcopv1alpha1.MyVaultType{},builder.WithPredicates(vaultresourcecontroller.NewDefaultPeriodicReconcilePredicate())).
         Complete(r)
     }
   ```

--- a/go.mod
+++ b/go.mod
@@ -71,6 +71,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect
@@ -79,6 +80,8 @@ require (
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/zclconf/go-cty v1.13.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -183,6 +183,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
@@ -192,6 +194,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/main.go
+++ b/main.go
@@ -137,6 +137,9 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Set the sync period for use in predicates
+	vaultresourcecontroller.SetSyncPeriod(syncPeriod)
+
 	if err = (&controllers.KubernetesAuthEngineRoleReconciler{ReconcilerBase: vaultresourcecontroller.NewFromManager(mgr, "KubernetesAuthEngineRole")}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KubernetesAuthEngineRole")
 		os.Exit(1)

--- a/readme.md
+++ b/readme.md
@@ -120,7 +120,7 @@ Additionally, the operator checks for an environment variable named `CACHE_VAULT
 
 By default, or if the variable is set to any other value, the operator will create a new client with a new token for each request it makes to Vault.
 
-SyncPeriod determines the minimum frequency at which watched resources are reconciled. Set the environment variable named `SYNC_PERIOD_SECONDS` to update the frequency at which watched resources are reconciled. It defaults to 10 hours if unset.
+SyncPeriod determines the minimum frequency at which watched resources are reconciled. Set the environment variable named `SYNC_PERIOD_SECONDS` to update the frequency at which watched resources are reconciled. It defaults to 10 hours if unset and ONLY works when `ENABLE_DRIFT_DETECTION` is set to `true`. The reconciliation also accounts for any drift that may have happened in Vault since the last reconciliation. This feature is disabled by default to maintain optimal performance.
 
 For certificates, the recommended approach is to mount the secret or configmap containing the certificate as described [here](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/subscription-config.md#volumes), and the configure the corresponding variables to point at the files location in the mounted path.
 


### PR DESCRIPTION
Fixes #285

### Problem
The ResourceGenerationChangedPredicate from PR #183 broke syncPeriod effectiveness - external Vault changes aren't detected because the predicate filters out cache refresh events when specs haven't changed.

### Solution
Unified PeriodicReconcilePredicate that:

- Always reconciles on spec changes (immediate response)
- Optionally enables periodic drift detection via ENABLE_DRIFT_DETECTION=true
- Uses existing SYNC_PERIOD_SECONDS for timing consistency

#### Configuration
export ENABLE_DRIFT_DETECTION=true  # Default: false
export SYNC_PERIOD_SECONDS=3600     # Existing setting

#### Changes
- Replaced ResourceGenerationChangedPredicate with unified predicate
- Added tests with testify/mock
- Updated controllers to use NewDefaultPeriodicReconcilePredicate()

Default behavior unchanged - drift detection is opt-in to preserve current performance.