### PR TITLE
fix: preserve existing one-off RandomSecret values on K8s resource re…

### DIFF
--- a/api/v1alpha1/utils/vaultobject.go
+++ b/api/v1alpha1/utils/vaultobject.go
@@ -103,8 +103,11 @@ func (ve *VaultEndpoint) Create(context context.Context) error {
 
 // CreateOrMergeKV reads existing KV secret data and merges the new payload keys into it.
 // This allows multiple resources to contribute different keys to the same Vault secret path.
+// When preserveExistingKeys is true, keys already present in Vault are not overwritten;
+// this protects one-off (non-rotating) secrets from being regenerated when the K8s resource
+// is recreated while the Vault secret still exists (e.g. with kvSecretRetainPolicy: Retain).
 // For KVv2, it expects the payload in {"data": {...}} format.
-func (ve *VaultEndpoint) CreateOrMergeKV(context context.Context, isKVv2 bool) error {
+func (ve *VaultEndpoint) CreateOrMergeKV(context context.Context, isKVv2 bool, preserveExistingKeys bool) error {
 	log := log.FromContext(context)
 	currentPayload, found, err := read(context, ve.vaultObject.GetPath())
 	if err != nil {
@@ -127,6 +130,12 @@ func (ve *VaultEndpoint) CreateOrMergeKV(context context.Context, isKVv2 bool) e
 			return write(context, ve.vaultObject.GetPath(), newPayload)
 		}
 		for k, v := range newData {
+			if preserveExistingKeys {
+				if _, exists := existingData[k]; exists {
+					log.Info("preserving existing key in Vault secret", "key", k, "path", ve.vaultObject.GetPath())
+					continue
+				}
+			}
 			existingData[k] = v
 		}
 		mergedPayload := map[string]interface{}{
@@ -136,6 +145,12 @@ func (ve *VaultEndpoint) CreateOrMergeKV(context context.Context, isKVv2 bool) e
 	}
 	// For KVv1, merge directly
 	for k, v := range newPayload {
+		if preserveExistingKeys {
+			if _, exists := currentPayload[k]; exists {
+				log.Info("preserving existing key in Vault secret", "key", k, "path", ve.vaultObject.GetPath())
+				continue
+			}
+		}
 		currentPayload[k] = v
 	}
 	return write(context, ve.vaultObject.GetPath(), currentPayload)

--- a/api/v1alpha1/utils/vaultobject_test.go
+++ b/api/v1alpha1/utils/vaultobject_test.go
@@ -1,0 +1,442 @@
+package utils
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	vault "github.com/hashicorp/vault/api"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// mockVaultObject implements VaultObject for testing.
+type mockVaultObject struct {
+	path    string
+	payload map[string]interface{}
+}
+
+func (m *mockVaultObject) GetPath() string                                    { return m.path }
+func (m *mockVaultObject) GetPayload() map[string]interface{}                 { return m.payload }
+func (m *mockVaultObject) IsEquivalentToDesiredState(_ map[string]interface{}) bool { return false }
+func (m *mockVaultObject) IsInitialized() bool                                { return true }
+func (m *mockVaultObject) IsValid() (bool, error)                             { return true, nil }
+func (m *mockVaultObject) IsDeletable() bool                                  { return true }
+func (m *mockVaultObject) PrepareInternalValues(_ context.Context, _ client.Object) error {
+	return nil
+}
+func (m *mockVaultObject) PrepareTLSConfig(_ context.Context, _ client.Object) error { return nil }
+func (m *mockVaultObject) GetKubeAuthConfiguration() *KubeAuthConfiguration        { return nil }
+func (m *mockVaultObject) GetVaultConnection() *VaultConnection                    { return nil }
+
+// fakeVaultStore holds in-memory KV data and serves Vault-compatible HTTP responses.
+type fakeVaultStore struct {
+	mu   sync.Mutex
+	data map[string]map[string]interface{}
+}
+
+func newFakeVaultStore() *fakeVaultStore {
+	return &fakeVaultStore{data: make(map[string]map[string]interface{})}
+}
+
+func (s *fakeVaultStore) set(path string, payload map[string]interface{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[path] = payload
+}
+
+func (s *fakeVaultStore) get(path string) (map[string]interface{}, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.data[path]
+	return v, ok
+}
+
+func (s *fakeVaultStore) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path[len("/v1/"):]
+		switch r.Method {
+		case http.MethodGet:
+			data, ok := s.get(path)
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			resp := map[string]interface{}{"data": data}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+		case http.MethodPut, http.MethodPost:
+			var body map[string]interface{}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			s.set(path, body)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+}
+
+func newTestContext(client *vault.Client) context.Context {
+	return context.WithValue(context.Background(), "vaultClient", client)
+}
+
+func newTestClient(t *testing.T, store *fakeVaultStore) (*vault.Client, *httptest.Server) {
+	t.Helper()
+	ts := httptest.NewServer(store.handler())
+	cfg := vault.DefaultConfig()
+	cfg.Address = ts.URL
+	client, err := vault.NewClient(cfg)
+	if err != nil {
+		t.Fatalf("failed to create vault client: %v", err)
+	}
+	return client, ts
+}
+
+// --- KVv1 tests ---
+
+func TestCreateOrMergeKV_KVv1_CreatesWhenPathNotFound(t *testing.T) {
+	store := newFakeVaultStore()
+	client, ts := newTestClient(t, store)
+	defer ts.Close()
+
+	obj := &mockVaultObject{
+		path:    "secret/myapp",
+		payload: map[string]interface{}{"password": "abc123"},
+	}
+	ve := &VaultEndpoint{vaultObject: obj}
+	ctx := newTestContext(client)
+
+	err := ve.CreateOrMergeKV(ctx, false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	stored, ok := store.get("secret/myapp")
+	if !ok {
+		t.Fatal("expected secret to be created")
+	}
+	if stored["password"] != "abc123" {
+		t.Errorf("expected password=abc123, got %v", stored["password"])
+	}
+}
+
+func TestCreateOrMergeKV_KVv1_MergesNewKey(t *testing.T) {
+	store := newFakeVaultStore()
+	store.set("secret/myapp", map[string]interface{}{"password": "existing-pw"})
+	client, ts := newTestClient(t, store)
+	defer ts.Close()
+
+	obj := &mockVaultObject{
+		path:    "secret/myapp",
+		payload: map[string]interface{}{"username": "admin"},
+	}
+	ve := &VaultEndpoint{vaultObject: obj}
+	ctx := newTestContext(client)
+
+	err := ve.CreateOrMergeKV(ctx, false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	stored, _ := store.get("secret/myapp")
+	if stored["password"] != "existing-pw" {
+		t.Errorf("existing key should be preserved, got %v", stored["password"])
+	}
+	if stored["username"] != "admin" {
+		t.Errorf("new key should be added, got %v", stored["username"])
+	}
+}
+
+func TestCreateOrMergeKV_KVv1_OverwritesExistingKey(t *testing.T) {
+	store := newFakeVaultStore()
+	store.set("secret/myapp", map[string]interface{}{"password": "old-value"})
+	client, ts := newTestClient(t, store)
+	defer ts.Close()
+
+	obj := &mockVaultObject{
+		path:    "secret/myapp",
+		payload: map[string]interface{}{"password": "new-value"},
+	}
+	ve := &VaultEndpoint{vaultObject: obj}
+	ctx := newTestContext(client)
+
+	err := ve.CreateOrMergeKV(ctx, false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	stored, _ := store.get("secret/myapp")
+	if stored["password"] != "new-value" {
+		t.Errorf("expected overwritten password=new-value, got %v", stored["password"])
+	}
+}
+
+func TestCreateOrMergeKV_KVv1_PreservesExistingKey(t *testing.T) {
+	store := newFakeVaultStore()
+	store.set("secret/myapp", map[string]interface{}{"password": "keep-this"})
+	client, ts := newTestClient(t, store)
+	defer ts.Close()
+
+	obj := &mockVaultObject{
+		path:    "secret/myapp",
+		payload: map[string]interface{}{"password": "would-overwrite"},
+	}
+	ve := &VaultEndpoint{vaultObject: obj}
+	ctx := newTestContext(client)
+
+	err := ve.CreateOrMergeKV(ctx, false, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	stored, _ := store.get("secret/myapp")
+	if stored["password"] != "keep-this" {
+		t.Errorf("expected preserved password=keep-this, got %v", stored["password"])
+	}
+}
+
+func TestCreateOrMergeKV_KVv1_PreserveAddsNewKeyButKeepsExisting(t *testing.T) {
+	store := newFakeVaultStore()
+	store.set("secret/myapp", map[string]interface{}{"password": "keep-this"})
+	client, ts := newTestClient(t, store)
+	defer ts.Close()
+
+	obj := &mockVaultObject{
+		path: "secret/myapp",
+		payload: map[string]interface{}{
+			"password": "would-overwrite",
+			"username": "new-user",
+		},
+	}
+	ve := &VaultEndpoint{vaultObject: obj}
+	ctx := newTestContext(client)
+
+	err := ve.CreateOrMergeKV(ctx, false, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	stored, _ := store.get("secret/myapp")
+	if stored["password"] != "keep-this" {
+		t.Errorf("existing key should be preserved, got %v", stored["password"])
+	}
+	if stored["username"] != "new-user" {
+		t.Errorf("new key should be added, got %v", stored["username"])
+	}
+}
+
+func TestCreateOrMergeKV_KVv1_PreserveCreatesWhenPathNotFound(t *testing.T) {
+	store := newFakeVaultStore()
+	client, ts := newTestClient(t, store)
+	defer ts.Close()
+
+	obj := &mockVaultObject{
+		path:    "secret/myapp",
+		payload: map[string]interface{}{"password": "first-value"},
+	}
+	ve := &VaultEndpoint{vaultObject: obj}
+	ctx := newTestContext(client)
+
+	err := ve.CreateOrMergeKV(ctx, false, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	stored, ok := store.get("secret/myapp")
+	if !ok {
+		t.Fatal("expected secret to be created")
+	}
+	if stored["password"] != "first-value" {
+		t.Errorf("expected password=first-value, got %v", stored["password"])
+	}
+}
+
+// --- KVv2 tests ---
+
+func TestCreateOrMergeKV_KVv2_CreatesWhenPathNotFound(t *testing.T) {
+	store := newFakeVaultStore()
+	client, ts := newTestClient(t, store)
+	defer ts.Close()
+
+	obj := &mockVaultObject{
+		path: "secret/data/myapp",
+		payload: map[string]interface{}{
+			"data": map[string]interface{}{"password": "abc123"},
+		},
+	}
+	ve := &VaultEndpoint{vaultObject: obj}
+	ctx := newTestContext(client)
+
+	err := ve.CreateOrMergeKV(ctx, true, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	stored, ok := store.get("secret/data/myapp")
+	if !ok {
+		t.Fatal("expected secret to be created")
+	}
+	data, _ := stored["data"].(map[string]interface{})
+	if data["password"] != "abc123" {
+		t.Errorf("expected password=abc123, got %v", data["password"])
+	}
+}
+
+func TestCreateOrMergeKV_KVv2_MergesNewKey(t *testing.T) {
+	store := newFakeVaultStore()
+	store.set("secret/data/myapp", map[string]interface{}{
+		"data": map[string]interface{}{"password": "existing-pw"},
+	})
+	client, ts := newTestClient(t, store)
+	defer ts.Close()
+
+	obj := &mockVaultObject{
+		path: "secret/data/myapp",
+		payload: map[string]interface{}{
+			"data": map[string]interface{}{"username": "admin"},
+		},
+	}
+	ve := &VaultEndpoint{vaultObject: obj}
+	ctx := newTestContext(client)
+
+	err := ve.CreateOrMergeKV(ctx, true, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	stored, _ := store.get("secret/data/myapp")
+	data, _ := stored["data"].(map[string]interface{})
+	if data["password"] != "existing-pw" {
+		t.Errorf("existing key should be preserved during merge, got %v", data["password"])
+	}
+	if data["username"] != "admin" {
+		t.Errorf("new key should be added, got %v", data["username"])
+	}
+}
+
+func TestCreateOrMergeKV_KVv2_OverwritesExistingKey(t *testing.T) {
+	store := newFakeVaultStore()
+	store.set("secret/data/myapp", map[string]interface{}{
+		"data": map[string]interface{}{"password": "old-value"},
+	})
+	client, ts := newTestClient(t, store)
+	defer ts.Close()
+
+	obj := &mockVaultObject{
+		path: "secret/data/myapp",
+		payload: map[string]interface{}{
+			"data": map[string]interface{}{"password": "new-value"},
+		},
+	}
+	ve := &VaultEndpoint{vaultObject: obj}
+	ctx := newTestContext(client)
+
+	err := ve.CreateOrMergeKV(ctx, true, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	stored, _ := store.get("secret/data/myapp")
+	data, _ := stored["data"].(map[string]interface{})
+	if data["password"] != "new-value" {
+		t.Errorf("expected overwritten password=new-value, got %v", data["password"])
+	}
+}
+
+func TestCreateOrMergeKV_KVv2_PreservesExistingKey(t *testing.T) {
+	store := newFakeVaultStore()
+	store.set("secret/data/myapp", map[string]interface{}{
+		"data": map[string]interface{}{"password": "keep-this"},
+	})
+	client, ts := newTestClient(t, store)
+	defer ts.Close()
+
+	obj := &mockVaultObject{
+		path: "secret/data/myapp",
+		payload: map[string]interface{}{
+			"data": map[string]interface{}{"password": "would-overwrite"},
+		},
+	}
+	ve := &VaultEndpoint{vaultObject: obj}
+	ctx := newTestContext(client)
+
+	err := ve.CreateOrMergeKV(ctx, true, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	stored, _ := store.get("secret/data/myapp")
+	data, _ := stored["data"].(map[string]interface{})
+	if data["password"] != "keep-this" {
+		t.Errorf("expected preserved password=keep-this, got %v", data["password"])
+	}
+}
+
+func TestCreateOrMergeKV_KVv2_PreserveAddsNewKeyButKeepsExisting(t *testing.T) {
+	store := newFakeVaultStore()
+	store.set("secret/data/myapp", map[string]interface{}{
+		"data": map[string]interface{}{"password": "keep-this"},
+	})
+	client, ts := newTestClient(t, store)
+	defer ts.Close()
+
+	obj := &mockVaultObject{
+		path: "secret/data/myapp",
+		payload: map[string]interface{}{
+			"data": map[string]interface{}{
+				"password": "would-overwrite",
+				"username": "new-user",
+			},
+		},
+	}
+	ve := &VaultEndpoint{vaultObject: obj}
+	ctx := newTestContext(client)
+
+	err := ve.CreateOrMergeKV(ctx, true, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	stored, _ := store.get("secret/data/myapp")
+	data, _ := stored["data"].(map[string]interface{})
+	if data["password"] != "keep-this" {
+		t.Errorf("existing key should be preserved, got %v", data["password"])
+	}
+	if data["username"] != "new-user" {
+		t.Errorf("new key should be added, got %v", data["username"])
+	}
+}
+
+func TestCreateOrMergeKV_KVv2_PreserveCreatesWhenPathNotFound(t *testing.T) {
+	store := newFakeVaultStore()
+	client, ts := newTestClient(t, store)
+	defer ts.Close()
+
+	obj := &mockVaultObject{
+		path: "secret/data/myapp",
+		payload: map[string]interface{}{
+			"data": map[string]interface{}{"password": "first-value"},
+		},
+	}
+	ve := &VaultEndpoint{vaultObject: obj}
+	ctx := newTestContext(client)
+
+	err := ve.CreateOrMergeKV(ctx, true, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	stored, ok := store.get("secret/data/myapp")
+	if !ok {
+		t.Fatal("expected secret to be created")
+	}
+	data, _ := stored["data"].(map[string]interface{})
+	if data["password"] != "first-value" {
+		t.Errorf("expected password=first-value, got %v", data["password"])
+	}
+}

--- a/controllers/randomsecret_controller.go
+++ b/controllers/randomsecret_controller.go
@@ -112,7 +112,6 @@ func (r *RandomSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		//we reschedule the next reconcile at the time in the future corresponding to
 		nextSchedule := time.Until(instance.Status.LastVaultSecretUpdate.Add(instance.Spec.RefreshPeriod.Duration))
 		if nextSchedule > 0 {
-			vaultresourcecontroller.ManageOutcomeWithRequeue(ctx, r.ReconcilerBase, instance, err, nextSchedule)
 			return vaultresourcecontroller.ManageOutcomeWithRequeue(ctx, r.ReconcilerBase, instance, err, nextSchedule)
 		} else {
 			return vaultresourcecontroller.ManageOutcomeWithRequeue(ctx, r.ReconcilerBase, instance, err, time.Second)
@@ -147,7 +146,8 @@ func (r *RandomSecretReconciler) manageCleanUpLogic(context context.Context, ins
 }
 
 func (r *RandomSecretReconciler) manageReconcileLogic(context context.Context, instance *redhatcopv1alpha1.RandomSecret) error {
-	// how to read this if: if the secret has been initialized once and there no refresh period or time ro refresh has not arrived yet, return.
+	// If the secret has been initialized once and there is no refresh period
+	// or time to refresh has not arrived yet, return.
 	if instance.Status.LastVaultSecretUpdate != nil && (instance.Spec.RefreshPeriod == nil || (instance.Spec.RefreshPeriod != nil && !instance.Status.LastVaultSecretUpdate.Add(instance.Spec.RefreshPeriod.Duration).Before(time.Now()))) {
 		return nil
 	}
@@ -157,7 +157,10 @@ func (r *RandomSecretReconciler) manageReconcileLogic(context context.Context, i
 		r.Log.Error(err, "unable to generate new secret", "instance", instance)
 		return err
 	}
-	err = vaultEndpoint.CreateOrMergeKV(context, instance.IsKVSecretsEngineV2())
+	// For one-off secrets (no rotation), preserve existing keys to avoid
+	// overwriting retained Vault secrets when the K8s resource is recreated.
+	preserveExisting := instance.Status.LastVaultSecretUpdate == nil && instance.Spec.RefreshPeriod == nil
+	err = vaultEndpoint.CreateOrMergeKV(context, instance.IsKVSecretsEngineV2(), preserveExisting)
 	if err != nil {
 		r.Log.Error(err, "unable to create/update Vault Secret", "instance", instance)
 		return err

--- a/controllers/randomsecret_controller_test.go
+++ b/controllers/randomsecret_controller_test.go
@@ -954,4 +954,388 @@ var _ = Describe("Random Secret controller for v2 secrets", func() {
 
 		})
 	})
+
+	Context("When recreating a multi-key RandomSecret with retain policy", func() {
+		It("Should preserve existing key values and not overwrite them on recreate", func() {
+
+			By("Creating a new PasswordPolicy")
+			passwordPolicySimplePasswordInstance, err := decoder.GetPasswordPolicyInstance("../test/randomsecret/v2/00-passwordpolicy-simple-password-policy-v2.yaml")
+			Expect(err).To(BeNil())
+			passwordPolicySimplePasswordInstance.Namespace = vaultAdminNamespaceName
+			Expect(k8sIntegrationClient.Create(ctx, passwordPolicySimplePasswordInstance)).Should(Succeed())
+
+			pplookupKey := types.NamespacedName{Name: passwordPolicySimplePasswordInstance.Name, Namespace: passwordPolicySimplePasswordInstance.Namespace}
+			ppCreated := &redhatcopv1alpha1.PasswordPolicy{}
+
+			Eventually(func() bool {
+				err := k8sIntegrationClient.Get(ctx, pplookupKey, ppCreated)
+				if err != nil {
+					return false
+				}
+				for _, condition := range ppCreated.Status.Conditions {
+					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			By("Creating new Policies")
+			policyKVEngineAdminInstance, err := decoder.GetPolicyInstance("../test/randomsecret/v2/01-policy-kv-engine-admin-v2.yaml")
+			Expect(err).To(BeNil())
+			policyKVEngineAdminInstance.Namespace = vaultAdminNamespaceName
+			Expect(k8sIntegrationClient.Create(ctx, policyKVEngineAdminInstance)).Should(Succeed())
+
+			pLookupKey := types.NamespacedName{Name: policyKVEngineAdminInstance.Name, Namespace: policyKVEngineAdminInstance.Namespace}
+			pCreated := &redhatcopv1alpha1.Policy{}
+
+			Eventually(func() bool {
+				err := k8sIntegrationClient.Get(ctx, pLookupKey, pCreated)
+				if err != nil {
+					return false
+				}
+				for _, condition := range pCreated.Status.Conditions {
+					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			policySecretWriterInstance, err := decoder.GetPolicyInstance("../test/randomsecret/v2/04-policy-secret-writer-v2.yaml")
+			Expect(err).To(BeNil())
+			policySecretWriterInstance.Namespace = vaultAdminNamespaceName
+			Expect(k8sIntegrationClient.Create(ctx, policySecretWriterInstance)).Should(Succeed())
+
+			pLookupKey = types.NamespacedName{Name: policySecretWriterInstance.Name, Namespace: policySecretWriterInstance.Namespace}
+			pCreated = &redhatcopv1alpha1.Policy{}
+
+			Eventually(func() bool {
+				err := k8sIntegrationClient.Get(ctx, pLookupKey, pCreated)
+				if err != nil {
+					return false
+				}
+				for _, condition := range pCreated.Status.Conditions {
+					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			By("Creating new KubernetesAuthEngineRoles")
+
+			kaerKVEngineAdminInstance, err := decoder.GetKubernetesAuthEngineRoleInstance("../test/randomsecret/v2/02-kubernetesauthenginerole-kv-engine-admin-v2.yaml")
+			Expect(err).To(BeNil())
+			kaerKVEngineAdminInstance.Namespace = vaultAdminNamespaceName
+			Expect(k8sIntegrationClient.Create(ctx, kaerKVEngineAdminInstance)).Should(Succeed())
+
+			kaerLookupKey := types.NamespacedName{Name: kaerKVEngineAdminInstance.Name, Namespace: kaerKVEngineAdminInstance.Namespace}
+			kaerCreated := &redhatcopv1alpha1.KubernetesAuthEngineRole{}
+
+			Eventually(func() bool {
+				err := k8sIntegrationClient.Get(ctx, kaerLookupKey, kaerCreated)
+				if err != nil {
+					return false
+				}
+				for _, condition := range kaerCreated.Status.Conditions {
+					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			kaerSecretWriterInstance, err := decoder.GetKubernetesAuthEngineRoleInstance("../test/randomsecret/v2/05-kubernetesauthenginerole-secret-writer-v2.yaml")
+			Expect(err).To(BeNil())
+			kaerSecretWriterInstance.Namespace = vaultAdminNamespaceName
+			Expect(k8sIntegrationClient.Create(ctx, kaerSecretWriterInstance)).Should(Succeed())
+
+			kaerLookupKey = types.NamespacedName{Name: kaerSecretWriterInstance.Name, Namespace: kaerSecretWriterInstance.Namespace}
+			kaerCreated = &redhatcopv1alpha1.KubernetesAuthEngineRole{}
+
+			Eventually(func() bool {
+				err := k8sIntegrationClient.Get(ctx, kaerLookupKey, kaerCreated)
+				if err != nil {
+					return false
+				}
+				for _, condition := range kaerCreated.Status.Conditions {
+					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			By("Creating a new SecretEngineMount")
+
+			semInstance, err := decoder.GetSecretEngineMountInstance("../test/randomsecret/v2/03-secretenginemount-kv-v2.yaml")
+			Expect(err).To(BeNil())
+			semInstance.Namespace = vaultTestNamespaceName
+			Expect(k8sIntegrationClient.Create(ctx, semInstance)).Should(Succeed())
+
+			semLookupKey := types.NamespacedName{Name: semInstance.Name, Namespace: semInstance.Namespace}
+			semCreated := &redhatcopv1alpha1.SecretEngineMount{}
+
+			Eventually(func() bool {
+				err := k8sIntegrationClient.Get(ctx, semLookupKey, semCreated)
+				if err != nil {
+					return false
+				}
+				for _, condition := range semCreated.Status.Conditions {
+					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			By("Creating first RandomSecret with password key")
+
+			rsPasswordInstance, err := decoder.GetRandomSecretInstance("../test/randomsecret/v2/09-randomsecret-multikey-password-v2.yaml")
+			Expect(err).To(BeNil())
+			rsPasswordInstance.Namespace = vaultTestNamespaceName
+			Expect(k8sIntegrationClient.Create(ctx, rsPasswordInstance)).Should(Succeed())
+
+			rsPasswordLookupKey := types.NamespacedName{Name: rsPasswordInstance.Name, Namespace: rsPasswordInstance.Namespace}
+			rsPasswordCreated := &redhatcopv1alpha1.RandomSecret{}
+
+			Eventually(func() bool {
+				err := k8sIntegrationClient.Get(ctx, rsPasswordLookupKey, rsPasswordCreated)
+				if err != nil {
+					return false
+				}
+				for _, condition := range rsPasswordCreated.Status.Conditions {
+					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			By("Creating second RandomSecret with username key at same path")
+
+			rsUsernameInstance, err := decoder.GetRandomSecretInstance("../test/randomsecret/v2/10-randomsecret-multikey-username-v2.yaml")
+			Expect(err).To(BeNil())
+			rsUsernameInstance.Namespace = vaultTestNamespaceName
+			Expect(k8sIntegrationClient.Create(ctx, rsUsernameInstance)).Should(Succeed())
+
+			rsUsernameLookupKey := types.NamespacedName{Name: rsUsernameInstance.Name, Namespace: rsUsernameInstance.Namespace}
+			rsUsernameCreated := &redhatcopv1alpha1.RandomSecret{}
+
+			Eventually(func() bool {
+				err := k8sIntegrationClient.Get(ctx, rsUsernameLookupKey, rsUsernameCreated)
+				if err != nil {
+					return false
+				}
+				for _, condition := range rsUsernameCreated.Status.Conditions {
+					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			By("Capturing original password and username values from Vault")
+
+			var originalPassword, originalUsername string
+			Eventually(func() error {
+				secret, err := vaultClient.Logical().Read(rsPasswordInstance.GetPath())
+				if err != nil {
+					return err
+				}
+				if secret == nil {
+					return fmt.Errorf("secret is nil")
+				}
+				data, ok := secret.Data["data"].(map[string]interface{})
+				if !ok {
+					return fmt.Errorf("data field is not a map")
+				}
+				pw, ok := data["password"]
+				if !ok {
+					return fmt.Errorf("password key not found")
+				}
+				un, ok := data["username"]
+				if !ok {
+					return fmt.Errorf("username key not found")
+				}
+				originalPassword = pw.(string)
+				originalUsername = un.(string)
+				return nil
+			}, timeout, interval).Should(Succeed())
+
+			Expect(originalPassword).NotTo(BeEmpty())
+			Expect(originalUsername).NotTo(BeEmpty())
+
+			By("Deleting the password RandomSecret K8s resource (Vault secret retained)")
+
+			Expect(k8sIntegrationClient.Delete(ctx, rsPasswordInstance)).Should(Succeed())
+
+			Eventually(func() bool {
+				err := k8sIntegrationClient.Get(ctx, rsPasswordLookupKey, rsPasswordCreated)
+				return err != nil
+			}, timeout, interval).Should(BeTrue())
+
+			By("Recreating the password RandomSecret K8s resource")
+
+			rsPasswordInstance, err = decoder.GetRandomSecretInstance("../test/randomsecret/v2/09-randomsecret-multikey-password-v2.yaml")
+			Expect(err).To(BeNil())
+			rsPasswordInstance.Namespace = vaultTestNamespaceName
+			Expect(k8sIntegrationClient.Create(ctx, rsPasswordInstance)).Should(Succeed())
+
+			rsPasswordCreated = &redhatcopv1alpha1.RandomSecret{}
+
+			Eventually(func() bool {
+				err := k8sIntegrationClient.Get(ctx, rsPasswordLookupKey, rsPasswordCreated)
+				if err != nil {
+					return false
+				}
+				for _, condition := range rsPasswordCreated.Status.Conditions {
+					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			By("Verifying both keys are preserved with their original values")
+
+			Eventually(func() error {
+				secret, err := vaultClient.Logical().Read(rsPasswordInstance.GetPath())
+				if err != nil {
+					return err
+				}
+				if secret == nil {
+					return fmt.Errorf("secret is nil")
+				}
+				data, ok := secret.Data["data"].(map[string]interface{})
+				if !ok {
+					return fmt.Errorf("data field is not a map")
+				}
+				pw, ok := data["password"]
+				if !ok {
+					return fmt.Errorf("password key not found")
+				}
+				if pw.(string) != originalPassword {
+					return fmt.Errorf("password was overwritten: expected %q, got %q", originalPassword, pw.(string))
+				}
+				un, ok := data["username"]
+				if !ok {
+					return fmt.Errorf("username key not found")
+				}
+				if un.(string) != originalUsername {
+					return fmt.Errorf("username was overwritten: expected %q, got %q", originalUsername, un.(string))
+				}
+				return nil
+			}, timeout, interval).Should(Succeed())
+
+			By("Cleaning up - Deleting RandomSecrets")
+
+			Expect(k8sIntegrationClient.Delete(ctx, rsPasswordInstance)).Should(Succeed())
+			Expect(k8sIntegrationClient.Delete(ctx, rsUsernameInstance)).Should(Succeed())
+
+			Eventually(func() bool {
+				err := k8sIntegrationClient.Get(ctx, rsPasswordLookupKey, rsPasswordCreated)
+				return err != nil
+			}, timeout, interval).Should(BeTrue())
+
+			Eventually(func() bool {
+				err := k8sIntegrationClient.Get(ctx, rsUsernameLookupKey, rsUsernameCreated)
+				return err != nil
+			}, timeout, interval).Should(BeTrue())
+
+			By("Deleting the SecretEngineMount")
+
+			Expect(k8sIntegrationClient.Delete(ctx, semInstance)).Should(Succeed())
+
+			Eventually(func() error {
+				secret, err := vaultClient.Logical().Read(semInstance.GetPath())
+				if secret == nil {
+					return nil
+				}
+				out, err := json.Marshal(secret)
+				if err != nil {
+					panic(err)
+				}
+				return fmt.Errorf("secret is not nil %s", string(out))
+			}, timeout, interval).Should(Succeed())
+
+			By("Deleting KubernetesAuthEngineRoles")
+
+			Expect(k8sIntegrationClient.Delete(ctx, kaerSecretWriterInstance)).Should(Succeed())
+
+			Eventually(func() error {
+				secret, err := vaultClient.Logical().Read(kaerSecretWriterInstance.GetPath())
+				if secret == nil {
+					return nil
+				}
+				out, err := json.Marshal(secret)
+				if err != nil {
+					panic(err)
+				}
+				return fmt.Errorf("secret is not nil %s", string(out))
+			}, timeout, interval).Should(Succeed())
+
+			Expect(k8sIntegrationClient.Delete(ctx, kaerKVEngineAdminInstance)).Should(Succeed())
+
+			Eventually(func() error {
+				secret, err := vaultClient.Logical().Read(kaerKVEngineAdminInstance.GetPath())
+				if secret == nil {
+					return nil
+				}
+				out, err := json.Marshal(secret)
+				if err != nil {
+					panic(err)
+				}
+				return fmt.Errorf("secret is not nil %s", string(out))
+			}, timeout, interval).Should(Succeed())
+
+			By("Deleting Policies")
+
+			Expect(k8sIntegrationClient.Delete(ctx, policySecretWriterInstance)).Should(Succeed())
+
+			Eventually(func() error {
+				secret, err := vaultClient.Logical().Read(policySecretWriterInstance.GetPath())
+				if secret == nil {
+					return nil
+				}
+				out, err := json.Marshal(secret)
+				if err != nil {
+					panic(err)
+				}
+				return fmt.Errorf("secret is not nil %s", string(out))
+			}, timeout, interval).Should(Succeed())
+
+			Expect(k8sIntegrationClient.Delete(ctx, policyKVEngineAdminInstance)).Should(Succeed())
+
+			Eventually(func() error {
+				secret, err := vaultClient.Logical().Read(policyKVEngineAdminInstance.GetPath())
+				if secret == nil {
+					return nil
+				}
+				out, err := json.Marshal(secret)
+				if err != nil {
+					panic(err)
+				}
+				return fmt.Errorf("secret is not nil %s", string(out))
+			}, timeout, interval).Should(Succeed())
+
+			By("Deleting PasswordPolicy")
+
+			Expect(k8sIntegrationClient.Delete(ctx, passwordPolicySimplePasswordInstance)).Should(Succeed())
+
+			Eventually(func() error {
+				secret, err := vaultClient.Logical().Read(passwordPolicySimplePasswordInstance.GetPath())
+				if secret == nil {
+					return nil
+				}
+				out, err := json.Marshal(secret)
+				if err != nil {
+					panic(err)
+				}
+				return fmt.Errorf("secret is not nil %s", string(out))
+			}, timeout, interval).Should(Succeed())
+
+		})
+	})
 })

--- a/docs/secret-management.md
+++ b/docs/secret-management.md
@@ -36,7 +36,7 @@ The `secretFormat` is a reference to a Vault Password policy, it can also suppli
 
 The `refreshPeriod` specifies the frequency at which this secret will be regenerated. This is an optional field, if not specified the secret will be generated once and then never updated.
 
-With a RandomSecret it is possible to build workflow in which the root password of a resource that we need to protect is never stored anywhere, except in vault. One way to achieve this is to have a random secret seed the root password. Then crete an operator that watches the RandomSecret and retrieves ths generated secret from vault and updates the resource to be protected. Finally configure the Secret Engine object to watch for the RandomSecret updates.
+With a RandomSecret it is possible to build workflow in which the root password of a resource that we need to protect is never stored anywhere, except in vault. One way to achieve this is to have a random secret seed the root password. Then create a configuration (VaultSecret for example) that watches the RandomSecret and retrieves the generated secret from Vault and uses it to configure the root password of the resource be protected. Finally configure the Secret Engine for the reosurce in question to watch for the RandomSecret updates.
 
 This CR is roughly equivalent to this Vault CLI command:
 
@@ -60,6 +60,52 @@ In addition to this, starting with v0.8.30, when a `RandomSecret` is created wit
 and with a corresponding *existing* Vault secret, this Vault secret will *not* be updated:
 this is intended to provide overwrite protection for Kubernetes recreate-after-delete actions
 and again avoid loosing the initially generated secret value.
+
+### Multiple keys on the same Vault path
+
+Vault allows storing multiple key/value pairs at the same path. You can use multiple `RandomSecret`
+resources that point to the same Vault path (via `spec.name`) but with different `secretKey` values
+to manage each key independently:
+
+```yaml
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: RandomSecret
+metadata:
+  name: myapp-password
+spec:
+  authentication:
+    path: kubernetes
+    role: secret-writer
+  path: kv/data
+  name: myapp-credentials
+  secretKey: password
+  secretFormat:
+    passwordPolicyName: complex-password
+  isKVSecretsEngineV2: true
+  kvSecretRetainPolicy: Retain
+---
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: RandomSecret
+metadata:
+  name: myapp-username
+spec:
+  authentication:
+    path: kubernetes
+    role: secret-writer
+  path: kv/data
+  name: myapp-credentials
+  secretKey: username
+  secretFormat:
+    passwordPolicyName: simple-username
+  isKVSecretsEngineV2: true
+  kvSecretRetainPolicy: Retain
+```
+
+Both resources contribute their respective key to the same Vault secret at `kv/myapp-credentials`.
+New keys are merged into existing data without affecting other keys at the same path.
+When combined with `kvSecretRetainPolicy: Retain` and no `refreshPeriod`, each key is individually
+protected from overwrite: if a `RandomSecret` Kubernetes resource is deleted and recreated, the
+existing key value in Vault is preserved rather than being regenerated.
 
 ## VaultSecret
 


### PR DESCRIPTION
…create (#313)

PR #300 introduced a regression where one-off RandomSecrets (no refreshPeriod) would overwrite their existing Vault values when the K8s resource was deleted and recreated with kvSecretRetainPolicy: Retain. This happened because the guard that prevented overwriting was removed when adding multi-key support.

Add a preserveExistingKeys parameter to CreateOrMergeKV so that keys already present in Vault are skipped during merge for one-off secrets, while still allowing new keys to be added (multi-key use case). Also fix a duplicate ManageOutcomeWithRequeue call in the reconcile loop.

Made-with: Cursor