### PR TITLE
fix(crd): package the namespaces CRD (add it to config/crd/kustomization.yaml

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -49,6 +49,7 @@ resources:
 - bases/redhatcop.redhat.io_identitytokenconfigs.yaml
 - bases/redhatcop.redhat.io_identitytokenkeys.yaml
 - bases/redhatcop.redhat.io_identitytokenroles.yaml
+- bases/redhatcop.redhat.io_namespaces.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge: []


### PR DESCRIPTION
The Namespace API introduced in #330 shipped its CRD base (config/crd/bases/redhatcop.redhat.io_namespaces.yaml), controller, and main.go registration, but the base was never added to the config/crd/kustomization.yaml resource list. As a result every generated packaging artifact — the Helm chart CRD bundle, the OLM bundle, and `make install` — contains only 47 of the 48 CRDs, omitting namespaces.redhatcop.redhat.io.

Because NamespaceReconciler is registered unconditionally, an operator installed from the chart (whose CRDs come only from that bundle) crashloops on startup: the manager cannot establish the Namespace informer cache and exits with "failed to wait for namespace caches to sync: timed out waiting for cache to be synced for Kind *v1alpha1.Namespace".

Add the base at the +kubebuilder:scaffold:crdkustomizeresource marker (where `kubebuilder create api` would have placed it), restoring the CRD to all packaging paths.

Verified:
- kustomize build config/crd -> 48 CRDs (was 47), now includes namespaces
- make manifests -> no drift
- make helmchart -> generated chart crds/ contains namespaces; helm lint passes
- make test -> all packages pass