### PR TITLE
fix: persist OpenShift version annotation and Namespace bundle metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,10 @@ IMAGE_TAG_BASE ?= quay.io/redhat-cop/$(OPERATOR_NAME)
 # BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
 BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 
+# Extra bundle annotations merged after generate bundle. operator-sdk --overwrite
+# regenerates bundle/metadata/annotations.yaml without these keys.
+BUNDLE_EXTRA_ANNOTATIONS ?= config/manifests/annotations.yaml
+
 # USE_IMAGE_DIGESTS defines if images are resolved via tags or digests
 # You can enable this value if you would like to use SHA Based Digests
 # To enable set flag to true
@@ -407,7 +411,7 @@ bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metada
 	$(OPERATOR_SDK) generate kustomize manifests --interactive=false -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
-	echo '  com.redhat.openshift.versions: v4.16' >> bundle/metadata/annotations.yaml
+	awk 'BEGIN {p=0} /^annotations:/{p=1; next} p && /^[^[:space:]#]/{p=0} p && /^[[:space:]]+[^#[:space:]]/{print}' $(BUNDLE_EXTRA_ANNOTATIONS) >> bundle/metadata/annotations.yaml
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: bundle-build

--- a/api/v1alpha1/namespace_types.go
+++ b/api/v1alpha1/namespace_types.go
@@ -118,7 +118,7 @@ func (m *Namespace) SetConditions(conditions []metav1.Condition) {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// Namespace is the Schema for the policies API
+// Namespace is the Schema for the namespaces API
 type Namespace struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/redhatcop.redhat.io_namespaces.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_namespaces.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Namespace is the Schema for the policies API
+        description: Namespace is the Schema for the namespaces API
         properties:
           apiVersion:
             description: |-

--- a/config/manifests/annotations.yaml
+++ b/config/manifests/annotations.yaml
@@ -1,0 +1,7 @@
+# Extra bundle metadata merged into bundle/metadata/annotations.yaml by `make bundle`
+# after `operator-sdk generate bundle --overwrite`. The SDK regenerates that file
+# from a fixed template and does not preserve custom keys.
+#
+# This file is not a kustomize resource. Do not list it under resources: below.
+annotations:
+  com.redhat.openshift.versions: v4.16

--- a/config/manifests/bases/vault-config-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/vault-config-operator.clusterserviceversion.yaml
@@ -226,6 +226,11 @@ spec:
       kind: LDAPAuthEngineGroup
       name: ldapauthenginegroups.redhatcop.redhat.io
       version: v1alpha1
+    - description: Namespace is the Schema for the namespaces API
+      displayName: Namespace
+      kind: Namespace
+      name: namespaces.redhatcop.redhat.io
+      version: v1alpha1
     - description: PasswordPolicy is the Schema for the passwordpolicies API
       displayName: Password Policy
       kind: PasswordPolicy

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -1,5 +1,7 @@
 # These resources constitute the fully configured set of manifests
 # used to generate the 'manifests/' directory in a bundle.
+# Extra bundle annotations are in annotations.yaml and are merged by `make bundle`;
+# do not add that file to resources.
 resources:
 - bases/vault-config-operator.clusterserviceversion.yaml
 - ../default


### PR DESCRIPTION
operator-sdk --overwrite drops custom bundle annotations, so merge them from config/manifests/annotations.yaml after generate. Also declare the Namespace owned CRD description so community-operators static checks stop warning.