### PR TITLE
Optional VaultSecret spec.output.type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,12 @@ VAULT_HOST_PORT ?= 8200
 # Override HTTPS_HOST_PORT and VAULT_HOST_PORT (along with KIND_CLUSTER_NAME) to run
 # parallel integration tests in separate Kind clusters — see project-context.md.
 HTTPS_HOST_PORT ?= 8443
+# Host port for kubectl port-forward to the Vault Service. Kind extraPortMappings
+# bind VAULT_HOST_PORT to ingress-nginx (node:80); that path is unreliable with
+# rootless Podman (TCP accept, then hang). Offset keeps the two listeners apart
+# and stays unique per worktree when VAULT_HOST_PORT is overridden.
+VAULT_API_PORT ?= $(shell echo $$(($(VAULT_HOST_PORT) + 10000)))
+VAULT_PF_PIDFILE ?= /tmp/$(KIND_CLUSTER_NAME)-vault-pf.pid
 KUBE_CONTEXT ?= kind-$(KIND_CLUSTER_NAME)
 KUBE_CONFIG_FILE ?= /tmp/$(KIND_CLUSTER_NAME)-kubeconfig
 # Container runtime: use docker in CI (GitHub Actions), podman on local dev machines.
@@ -151,10 +157,35 @@ test: manifests generate fmt vet envtest ## Run tests.
 
 # note: envtest requires a container runtime (docker or podman)
 .PHONY: integration
-integration: kind-setup deploy-vault deploy-ingress deploy-postgresql deploy-rabbitmq deploy-ldap deploy-keycloak deploy-nomad vault manifests generate fmt vet envtest ## Run tests.
+integration: kind-setup deploy-vault deploy-ingress deploy-postgresql deploy-rabbitmq deploy-ldap deploy-keycloak deploy-nomad vault-port-forward vault manifests generate fmt vet envtest ## Run tests.
 	export VAULT_TOKEN=$$(KUBECONFIG=$(KUBE_CONFIG_FILE) $(KUBECTL) --context $(KUBE_CONTEXT) get secret vault-init -n vault -o jsonpath='{.data.root_token}' | base64 -d) ;\
-	export VAULT_ADDR="http://localhost:$(VAULT_HOST_PORT)" ;\
+	export VAULT_ADDR="http://127.0.0.1:$(VAULT_API_PORT)" ;\
 	KUBECONFIG=$(KUBE_CONFIG_FILE) KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out --tags=integration -timeout 30m
+
+.PHONY: vault-port-forward
+vault-port-forward: kubectl ## Port-forward Vault API to the host (avoids Kind extraPortMappings).
+	@if [ -f $(VAULT_PF_PIDFILE) ]; then \
+	  PF_PID=$$(cat $(VAULT_PF_PIDFILE)); \
+	  if kill -0 $$PF_PID 2>/dev/null && curl -fsS --max-time 2 http://127.0.0.1:$(VAULT_API_PORT)/v1/sys/health >/dev/null 2>&1; then \
+	    echo "Vault port-forward already running (pid $$PF_PID) on 127.0.0.1:$(VAULT_API_PORT)"; \
+	    exit 0; \
+	  fi; \
+	  kill $$PF_PID 2>/dev/null || true; \
+	  rm -f $(VAULT_PF_PIDFILE); \
+	fi; \
+	echo "Port-forwarding Vault API to http://127.0.0.1:$(VAULT_API_PORT) (bypasses Kind extraPortMappings / rootless Podman)"; \
+	KUBECONFIG=$(KUBE_CONFIG_FILE) setsid $(KUBECTL) --context $(KUBE_CONTEXT) port-forward -n vault --address 127.0.0.1 svc/vault $(VAULT_API_PORT):8200 >/tmp/$(KIND_CLUSTER_NAME)-vault-pf.log 2>&1 < /dev/null & \
+	echo $$! > $(VAULT_PF_PIDFILE); \
+	for i in $$(seq 1 30); do \
+	  if curl -fsS --max-time 1 http://127.0.0.1:$(VAULT_API_PORT)/v1/sys/health >/dev/null 2>&1; then \
+	    echo "Vault API reachable at http://127.0.0.1:$(VAULT_API_PORT)"; \
+	    exit 0; \
+	  fi; \
+	  sleep 1; \
+	done; \
+	echo "Vault port-forward failed to become ready. Log:"; \
+	cat /tmp/$(KIND_CLUSTER_NAME)-vault-pf.log; \
+	exit 1
 
 .PHONY: deploy-ingress
 deploy-ingress: kubectl helm
@@ -203,7 +234,11 @@ kind-teardown: kind ## Delete the Kind cluster and its kubeconfig.
 	else \
 	  echo "Kind cluster '$(KIND_CLUSTER_NAME)' does not exist, nothing to delete"; \
 	fi
-	@rm -f $(KUBE_CONFIG_FILE)
+	@if [ -f $(VAULT_PF_PIDFILE) ]; then \
+	  kill $$(cat $(VAULT_PF_PIDFILE)) 2>/dev/null || true; \
+	  rm -f $(VAULT_PF_PIDFILE); \
+	fi
+	@rm -f $(KUBE_CONFIG_FILE) /tmp/$(KIND_CLUSTER_NAME)-vault-pf.log
 
 .PHONY: deploy-postgresql
 deploy-postgresql: kubectl helm
@@ -241,22 +276,42 @@ deploy-nomad: kubectl
 		exit 1 ;\
 	}
 	@echo "Bootstrapping Nomad ACLs..."
-	@NOMAD_POD=$$($(KUBECTL) --context $(KUBE_CONTEXT) get pods -n nomad -l app=nomad -o jsonpath='{.items[0].metadata.name}') ;\
+	@set +e; \
+	NOMAD_POD=$$($(KUBECTL) --context $(KUBE_CONTEXT) get pods -n nomad -l app=nomad -o jsonpath='{.items[0].metadata.name}') ;\
+	BOOTSTRAP_ERR=/tmp/$(KIND_CLUSTER_NAME)-nomad-bootstrap.err ;\
+	extract_secret() { sed -n 's/.*"SecretID"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p'; } ;\
 	NOMAD_TOKEN="" ;\
 	for i in 1 2 3 4 5 6 7 8 9 10; do \
-		NOMAD_TOKEN=$$($(KUBECTL) --context $(KUBE_CONTEXT) exec -n nomad $$NOMAD_POD -- sh -c 'nomad acl bootstrap -json 2>/dev/null | grep -o "\"SecretID\":\"[^\"]*\"" | cut -d\" -f4' 2>/dev/null || echo "") ;\
+		BOOTSTRAP_OUT=$$($(KUBECTL) --context $(KUBE_CONTEXT) exec -n nomad $$NOMAD_POD -- nomad acl bootstrap -json 2>&1) ;\
+		printf '%s\n' "$$BOOTSTRAP_OUT" > $$BOOTSTRAP_ERR ;\
+		NOMAD_TOKEN=$$(printf '%s\n' "$$BOOTSTRAP_OUT" | extract_secret) ;\
 		if [ -n "$$NOMAD_TOKEN" ]; then break; fi ;\
+		if printf '%s\n' "$$BOOTSTRAP_OUT" | grep -Eq 'ACL bootstrap already done|Invalid bootstrap reset index'; then break; fi ;\
 		echo "Waiting for Nomad ACL system to be ready (attempt $$i/10)..." ;\
 		sleep 2 ;\
 	done ;\
 	if [ -z "$$NOMAD_TOKEN" ]; then \
 		echo "Nomad ACL already bootstrapped or bootstrap failed, trying to read existing secret..." ;\
-		NOMAD_TOKEN=$$($(KUBECTL) --context $(KUBE_CONTEXT) get secret nomad-token-secret -n vault-admin -o jsonpath='{.data.token}' 2>/dev/null | base64 -d) ;\
+		NOMAD_TOKEN=$$($(KUBECTL) --context $(KUBE_CONTEXT) get secret nomad-token-secret -n vault-admin -o jsonpath='{.data.token}' 2>/dev/null | base64 -d || true) ;\
+	fi ;\
+	if [ -z "$$NOMAD_TOKEN" ]; then \
+		RESET_INDEX=$$(sed -n 's/.*reset index: \([0-9]*\).*/\1/p' $$BOOTSTRAP_ERR) ;\
+		if [ -n "$$RESET_INDEX" ]; then \
+			echo "ACL token secret missing; resetting Nomad ACL bootstrap (index $$RESET_INDEX)..." ;\
+			$(KUBECTL) --context $(KUBE_CONTEXT) exec -n nomad $$NOMAD_POD -- sh -c "echo $$RESET_INDEX > /tmp/nomad/server/acl-bootstrap-reset" ;\
+			BOOTSTRAP_OUT=$$($(KUBECTL) --context $(KUBE_CONTEXT) exec -n nomad $$NOMAD_POD -- nomad acl bootstrap -json 2>&1) ;\
+			printf '%s\n' "$$BOOTSTRAP_OUT" > $$BOOTSTRAP_ERR ;\
+			NOMAD_TOKEN=$$(printf '%s\n' "$$BOOTSTRAP_OUT" | extract_secret) ;\
+			$(KUBECTL) --context $(KUBE_CONTEXT) exec -n nomad $$NOMAD_POD -- rm -f /tmp/nomad/server/acl-bootstrap-reset >/dev/null 2>&1 || true ;\
+		fi ;\
 	fi ;\
 	if [ -z "$$NOMAD_TOKEN" ]; then \
 		echo "ERROR: Could not obtain Nomad management token." ;\
+		echo "--- nomad acl bootstrap output ---" ;\
+		cat $$BOOTSTRAP_ERR ;\
 		exit 1 ;\
 	fi ;\
+	set -e ;\
 	echo "Creating readonly ACL policy in Nomad..." ;\
 	echo 'namespace "default" { policy = "read" }' | $(KUBECTL) --context $(KUBE_CONTEXT) exec -i -n nomad $$NOMAD_POD -- sh -c "NOMAD_TOKEN=$$NOMAD_TOKEN nomad acl policy apply readonly -" ;\
 	echo "Creating Nomad token K8s secret..." ;\

--- a/api/v1alpha1/vaultsecret_types.go
+++ b/api/v1alpha1/vaultsecret_types.go
@@ -158,7 +158,7 @@ type TemplatizedK8sSecret struct {
 	// +kubebuilder:validation:Required
 	Name string `json:"name,omitempty"`
 	// Type is the K8s Secret type to output to.
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	Type string `json:"type,omitempty"`
 	// StringData is the K8s Secret stringData and allows specifying non-binary secret data in string form with go templating support
 	// to transform the Vault KV secrets into a formatted K8s Secret.

--- a/config/crd/bases/redhatcop.redhat.io_vaultsecrets.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_vaultsecrets.yaml
@@ -71,7 +71,6 @@ spec:
                 required:
                 - name
                 - stringData
-                - type
                 type: object
               refreshPeriod:
                 description: |-

--- a/integration/manifests/ingress-nginx-kind-deploy.yaml
+++ b/integration/manifests/ingress-nginx-kind-deploy.yaml
@@ -320,7 +320,8 @@ subjects:
   namespace: ingress-nginx
 ---
 apiVersion: v1
-data: null
+data:
+  worker-processes: "4"
 kind: ConfigMap
 metadata:
   labels:

--- a/internal/controller/suite_integration_test.go
+++ b/internal/controller/suite_integration_test.go
@@ -21,11 +21,12 @@ package controller
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
-
-	"net/http"
+	"time"
 
 	vault "github.com/hashicorp/vault/api"
 	. "github.com/onsi/ginkgo/v2"
@@ -91,8 +92,15 @@ var _ = BeforeSuite(func() {
 		vaultAddress = os.Getenv("VAULT_ADDR")
 	}
 
-	_, err := http.Get(os.Getenv("VAULT_ADDR"))
-	Expect(err).To(BeNil())
+	// Probe /v1/sys/health with a timeout. http.Get on VAULT_ADDR follows Vault's
+	// 307 to /ui/, which hangs, and Kind extraPortMappings via rootless Podman
+	// often accept TCP then never return bytes.
+	healthURL := strings.TrimRight(vaultAddress, "/") + "/v1/sys/health"
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	resp, err := httpClient.Get(healthURL)
+	Expect(err).To(BeNil(), fmt.Sprintf("Vault is not reachable at %s", healthURL))
+	defer resp.Body.Close()
+	Expect(resp.StatusCode).To(Equal(http.StatusOK), fmt.Sprintf("Vault health at %s returned %s", healthURL, resp.Status))
 
 	vaultToken, isSet := os.LookupEnv("VAULT_TOKEN")
 	Expect(isSet).To(BeTrue())

--- a/internal/controller/vaultsecret_controller_test.go
+++ b/internal/controller/vaultsecret_controller_test.go
@@ -321,6 +321,51 @@ var _ = Describe("VaultSecret controller", func() {
 				Expect(len(s)).To(Equal(20))
 			}
 
+			By("Checking the Secret type defaults to Opaque when VaultSecret output type is unset")
+			Expect(instance.Spec.TemplatizedK8sSecret.Type).To(BeEmpty())
+			Expect(secret.Type).To(Equal(corev1.SecretTypeOpaque))
+
+			By("Creating a VaultSecret with output type set")
+			typedName, err := decoder.CreateFromYAML(ctx, k8sIntegrationClient, "../../test/vaultsecret/vaultsecret-randomsecret-typed.yaml", vaultTestNamespaceName)
+			Expect(err).To(BeNil())
+			typedInstance := &redhatcopv1alpha1.VaultSecret{}
+			Expect(k8sIntegrationClient.Get(ctx, types.NamespacedName{Name: typedName, Namespace: vaultTestNamespaceName}, typedInstance)).Should(Succeed())
+			typedVSKey := types.NamespacedName{Name: typedInstance.Name, Namespace: typedInstance.Namespace}
+			typedCreated := &redhatcopv1alpha1.VaultSecret{}
+			Eventually(func() bool {
+				err := k8sIntegrationClient.Get(ctx, typedVSKey, typedCreated)
+				if err != nil {
+					return false
+				}
+				for _, condition := range typedCreated.Status.Conditions {
+					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			By("Checking the Secret type matches the VaultSecret output type")
+			Expect(typedCreated.Spec.TemplatizedK8sSecret.Type).To(Equal(string(corev1.SecretTypeBasicAuth)))
+			typedSecretKey := types.NamespacedName{Name: typedCreated.Spec.TemplatizedK8sSecret.Name, Namespace: typedCreated.Namespace}
+			typedSecret := &corev1.Secret{}
+			Eventually(func() bool {
+				err := k8sIntegrationClient.Get(ctx, typedSecretKey, typedSecret)
+				if err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+			Expect(typedSecret.Type).To(Equal(corev1.SecretType(typedCreated.Spec.TemplatizedK8sSecret.Type)))
+			Expect(typedSecret.Type).To(Equal(corev1.SecretTypeBasicAuth))
+
+			By("Deleting the typed VaultSecret")
+			Expect(k8sIntegrationClient.Delete(ctx, typedInstance)).Should(Succeed())
+			Eventually(func() bool {
+				err := k8sIntegrationClient.Get(ctx, typedSecretKey, &corev1.Secret{})
+				return err != nil
+			}, timeout, interval).Should(BeTrue())
+
 			By("Recording the initial ObservedGeneration from VaultSecret conditions")
 			vsLookupKey := types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}
 			Expect(k8sIntegrationClient.Get(ctx, vsLookupKey, created)).Should(Succeed())

--- a/internal/controller/vaultsecret_controller_v2_test.go
+++ b/internal/controller/vaultsecret_controller_v2_test.go
@@ -92,6 +92,39 @@ var _ = Describe("VaultSecret controller for v2 secrets", func() {
 				Expect(len(s)).To(Equal(20))
 			}
 
+			By("Checking the Secret type defaults to Opaque when VaultSecret output type is unset")
+			Expect(instance.Spec.TemplatizedK8sSecret.Type).To(BeEmpty())
+			Expect(secret.Type).To(Equal(corev1.SecretTypeOpaque))
+
+			By("Creating a VaultSecret with output type set")
+			typedName, err := decoder.CreateFromYAML(ctx, k8sIntegrationClient, "../../test/vaultsecret/v2/09-vaultsecret-randomsecret-typed-v2.yaml", vaultTestNamespaceName)
+			Expect(err).To(BeNil())
+			typedInstance := &redhatcopv1alpha1.VaultSecret{}
+			Expect(k8sIntegrationClient.Get(ctx, types.NamespacedName{Name: typedName, Namespace: vaultTestNamespaceName}, typedInstance)).Should(Succeed())
+			typedCreated := &redhatcopv1alpha1.VaultSecret{}
+			waitForReconcileSuccess(ctx, types.NamespacedName{Name: typedInstance.Name, Namespace: typedInstance.Namespace}, typedCreated, timeout, interval)
+
+			By("Checking the Secret type matches the VaultSecret output type")
+			Expect(typedCreated.Spec.TemplatizedK8sSecret.Type).To(Equal(string(corev1.SecretTypeBasicAuth)))
+			typedSecretKey := types.NamespacedName{Name: typedCreated.Spec.TemplatizedK8sSecret.Name, Namespace: typedCreated.Namespace}
+			typedSecret := &corev1.Secret{}
+			Eventually(func() bool {
+				err := k8sIntegrationClient.Get(ctx, typedSecretKey, typedSecret)
+				if err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+			Expect(typedSecret.Type).To(Equal(corev1.SecretType(typedCreated.Spec.TemplatizedK8sSecret.Type)))
+			Expect(typedSecret.Type).To(Equal(corev1.SecretTypeBasicAuth))
+
+			By("Deleting the typed VaultSecret")
+			Expect(k8sIntegrationClient.Delete(ctx, typedInstance)).Should(Succeed())
+			Eventually(func() bool {
+				err := k8sIntegrationClient.Get(ctx, typedSecretKey, &corev1.Secret{})
+				return err != nil
+			}, timeout, interval).Should(BeTrue())
+
 			By("Deleting the VaultSecret")
 
 			Expect(k8sIntegrationClient.Delete(ctx, instance)).Should(Succeed())

--- a/readme.md
+++ b/readme.md
@@ -758,7 +758,7 @@ oc apply -f test/olm/subscription-vault-config-operator-v0-0-1-sub.yaml -n vault
 
 ## Integration Test
 
-> Note the envtest seems to only work with kind when using docker instead of podman
+> Integration tests reach Vault via `kubectl port-forward` (`VAULT_API_PORT`, default 18200). Kind extraPortMappings through rootless Podman (host → ingress-nginx hostPort) often accept TCP and then hang.
 
 ```sh
 make integration

--- a/test/vaultsecret/v2/07-vaultsecret-randomsecret-v2.yaml
+++ b/test/vaultsecret/v2/07-vaultsecret-randomsecret-v2.yaml
@@ -23,7 +23,7 @@ spec:
     stringData:
       password: '{{ .test.password }}'
       password2: '{{ .test2.password }}'
-    type: Opaque
+    # type: Opaque
     labels:
       app: test-vault-config-operator
     annotations:

--- a/test/vaultsecret/v2/08-vaultsecret-randomsecret-retain-v2.yaml
+++ b/test/vaultsecret/v2/08-vaultsecret-randomsecret-retain-v2.yaml
@@ -15,7 +15,7 @@ spec:
     name: randomsecret-retain-v2
     stringData:
       password: '{{ .test.password }}'
-    type: Opaque
+    # type: Opaque
     labels:
       app: test-vault-config-operator
     annotations:

--- a/test/vaultsecret/v2/09-vaultsecret-randomsecret-typed-v2.yaml
+++ b/test/vaultsecret/v2/09-vaultsecret-randomsecret-typed-v2.yaml
@@ -1,0 +1,20 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: randomsecret-typed-v2
+spec:
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader-v2
+        serviceAccount:
+          name: default
+      name: test
+      path: test-vault-config-operator/kv-v2/data/randomsecret-password-v2
+  output:
+    name: randomsecret-typed-v2
+    stringData:
+      username: vault-user
+      password: '{{ .test.password }}'
+    type: kubernetes.io/basic-auth
+  refreshPeriod: 3m0s

--- a/test/vaultsecret/vaultsecret-dynamicsecret.yaml
+++ b/test/vaultsecret/vaultsecret-dynamicsecret.yaml
@@ -16,7 +16,7 @@ spec:
     stringData:
       username: '{{ .dynamicsecret.username }}'
       password: '{{ .dynamicsecret.password }}'
-    type: Opaque
+    # type: Opaque
     labels:
       app: test-label
     annotations:

--- a/test/vaultsecret/vaultsecret-randomsecret-typed.yaml
+++ b/test/vaultsecret/vaultsecret-randomsecret-typed.yaml
@@ -1,0 +1,20 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: randomsecret-typed
+spec:
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: randomsecret
+      path: test-vault-config-operator/kv/randomsecret-password
+  output:
+    name: randomsecret-typed
+    stringData:
+      username: vault-user
+      password: '{{ .randomsecret.password }}'
+    type: kubernetes.io/basic-auth
+  refreshPeriod: 3m0s

--- a/test/vaultsecret/vaultsecret-randomsecret.yaml
+++ b/test/vaultsecret/vaultsecret-randomsecret.yaml
@@ -23,7 +23,7 @@ spec:
     stringData:
       password: '{{ .randomsecret.password }}'
       anotherpassword: '{{ .anotherrandomsecret.password }}'
-    type: Opaque
+    # type: Opaque
     labels:
       app: test-vault-config-operator
     annotations:


### PR DESCRIPTION
This makes the VaultSecret spec.output.type Optional and changes the integration test so that kind works with podman.
Issue #363 