### PR TITLE
VaultSecret spec.output.type Optional

### DIFF
--- a/api/v1alpha1/vaultsecret_types.go
+++ b/api/v1alpha1/vaultsecret_types.go
@@ -158,7 +158,7 @@ type TemplatizedK8sSecret struct {
 	// +kubebuilder:validation:Required
 	Name string `json:"name,omitempty"`
 	// Type is the K8s Secret type to output to.
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	Type string `json:"type,omitempty"`
 	// StringData is the K8s Secret stringData and allows specifying non-binary secret data in string form with go templating support
 	// to transform the Vault KV secrets into a formatted K8s Secret.

--- a/config/crd/bases/redhatcop.redhat.io_vaultsecrets.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_vaultsecrets.yaml
@@ -71,7 +71,6 @@ spec:
                 required:
                 - name
                 - stringData
-                - type
                 type: object
               refreshPeriod:
                 description: |-

--- a/internal/controller/vaultsecret_controller_test.go
+++ b/internal/controller/vaultsecret_controller_test.go
@@ -321,6 +321,51 @@ var _ = Describe("VaultSecret controller", func() {
 				Expect(len(s)).To(Equal(20))
 			}
 
+			By("Checking the Secret type defaults to Opaque when VaultSecret output type is unset")
+			Expect(instance.Spec.TemplatizedK8sSecret.Type).To(BeEmpty())
+			Expect(secret.Type).To(Equal(corev1.SecretTypeOpaque))
+
+			By("Creating a VaultSecret with output type set")
+			typedName, err := decoder.CreateFromYAML(ctx, k8sIntegrationClient, "../../test/vaultsecret/vaultsecret-randomsecret-typed.yaml", vaultTestNamespaceName)
+			Expect(err).To(BeNil())
+			typedInstance := &redhatcopv1alpha1.VaultSecret{}
+			Expect(k8sIntegrationClient.Get(ctx, types.NamespacedName{Name: typedName, Namespace: vaultTestNamespaceName}, typedInstance)).Should(Succeed())
+			typedVSKey := types.NamespacedName{Name: typedInstance.Name, Namespace: typedInstance.Namespace}
+			typedCreated := &redhatcopv1alpha1.VaultSecret{}
+			Eventually(func() bool {
+				err := k8sIntegrationClient.Get(ctx, typedVSKey, typedCreated)
+				if err != nil {
+					return false
+				}
+				for _, condition := range typedCreated.Status.Conditions {
+					if condition.Type == vaultresourcecontroller.ReconcileSuccessful && condition.Status == metav1.ConditionTrue {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			By("Checking the Secret type matches the VaultSecret output type")
+			Expect(typedCreated.Spec.TemplatizedK8sSecret.Type).To(Equal(string(corev1.SecretTypeBasicAuth)))
+			typedSecretKey := types.NamespacedName{Name: typedCreated.Spec.TemplatizedK8sSecret.Name, Namespace: typedCreated.Namespace}
+			typedSecret := &corev1.Secret{}
+			Eventually(func() bool {
+				err := k8sIntegrationClient.Get(ctx, typedSecretKey, typedSecret)
+				if err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+			Expect(typedSecret.Type).To(Equal(corev1.SecretType(typedCreated.Spec.TemplatizedK8sSecret.Type)))
+			Expect(typedSecret.Type).To(Equal(corev1.SecretTypeBasicAuth))
+
+			By("Deleting the typed VaultSecret")
+			Expect(k8sIntegrationClient.Delete(ctx, typedInstance)).Should(Succeed())
+			Eventually(func() bool {
+				err := k8sIntegrationClient.Get(ctx, typedSecretKey, &corev1.Secret{})
+				return err != nil
+			}, timeout, interval).Should(BeTrue())
+
 			By("Recording the initial ObservedGeneration from VaultSecret conditions")
 			vsLookupKey := types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}
 			Expect(k8sIntegrationClient.Get(ctx, vsLookupKey, created)).Should(Succeed())

--- a/internal/controller/vaultsecret_controller_v2_test.go
+++ b/internal/controller/vaultsecret_controller_v2_test.go
@@ -92,6 +92,39 @@ var _ = Describe("VaultSecret controller for v2 secrets", func() {
 				Expect(len(s)).To(Equal(20))
 			}
 
+			By("Checking the Secret type defaults to Opaque when VaultSecret output type is unset")
+			Expect(instance.Spec.TemplatizedK8sSecret.Type).To(BeEmpty())
+			Expect(secret.Type).To(Equal(corev1.SecretTypeOpaque))
+
+			By("Creating a VaultSecret with output type set")
+			typedName, err := decoder.CreateFromYAML(ctx, k8sIntegrationClient, "../../test/vaultsecret/v2/09-vaultsecret-randomsecret-typed-v2.yaml", vaultTestNamespaceName)
+			Expect(err).To(BeNil())
+			typedInstance := &redhatcopv1alpha1.VaultSecret{}
+			Expect(k8sIntegrationClient.Get(ctx, types.NamespacedName{Name: typedName, Namespace: vaultTestNamespaceName}, typedInstance)).Should(Succeed())
+			typedCreated := &redhatcopv1alpha1.VaultSecret{}
+			waitForReconcileSuccess(ctx, types.NamespacedName{Name: typedInstance.Name, Namespace: typedInstance.Namespace}, typedCreated, timeout, interval)
+
+			By("Checking the Secret type matches the VaultSecret output type")
+			Expect(typedCreated.Spec.TemplatizedK8sSecret.Type).To(Equal(string(corev1.SecretTypeBasicAuth)))
+			typedSecretKey := types.NamespacedName{Name: typedCreated.Spec.TemplatizedK8sSecret.Name, Namespace: typedCreated.Namespace}
+			typedSecret := &corev1.Secret{}
+			Eventually(func() bool {
+				err := k8sIntegrationClient.Get(ctx, typedSecretKey, typedSecret)
+				if err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+			Expect(typedSecret.Type).To(Equal(corev1.SecretType(typedCreated.Spec.TemplatizedK8sSecret.Type)))
+			Expect(typedSecret.Type).To(Equal(corev1.SecretTypeBasicAuth))
+
+			By("Deleting the typed VaultSecret")
+			Expect(k8sIntegrationClient.Delete(ctx, typedInstance)).Should(Succeed())
+			Eventually(func() bool {
+				err := k8sIntegrationClient.Get(ctx, typedSecretKey, &corev1.Secret{})
+				return err != nil
+			}, timeout, interval).Should(BeTrue())
+
 			By("Deleting the VaultSecret")
 
 			Expect(k8sIntegrationClient.Delete(ctx, instance)).Should(Succeed())

--- a/test/vaultsecret/v2/07-vaultsecret-randomsecret-v2.yaml
+++ b/test/vaultsecret/v2/07-vaultsecret-randomsecret-v2.yaml
@@ -23,7 +23,7 @@ spec:
     stringData:
       password: '{{ .test.password }}'
       password2: '{{ .test2.password }}'
-    type: Opaque
+    # type: Opaque
     labels:
       app: test-vault-config-operator
     annotations:

--- a/test/vaultsecret/v2/08-vaultsecret-randomsecret-retain-v2.yaml
+++ b/test/vaultsecret/v2/08-vaultsecret-randomsecret-retain-v2.yaml
@@ -15,7 +15,7 @@ spec:
     name: randomsecret-retain-v2
     stringData:
       password: '{{ .test.password }}'
-    type: Opaque
+    # type: Opaque
     labels:
       app: test-vault-config-operator
     annotations:

--- a/test/vaultsecret/v2/09-vaultsecret-randomsecret-typed-v2.yaml
+++ b/test/vaultsecret/v2/09-vaultsecret-randomsecret-typed-v2.yaml
@@ -1,0 +1,20 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: randomsecret-typed-v2
+spec:
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader-v2
+        serviceAccount:
+          name: default
+      name: test
+      path: test-vault-config-operator/kv-v2/data/randomsecret-password-v2
+  output:
+    name: randomsecret-typed-v2
+    stringData:
+      username: vault-user
+      password: '{{ .test.password }}'
+    type: kubernetes.io/basic-auth
+  refreshPeriod: 3m0s

--- a/test/vaultsecret/vaultsecret-dynamicsecret.yaml
+++ b/test/vaultsecret/vaultsecret-dynamicsecret.yaml
@@ -16,7 +16,7 @@ spec:
     stringData:
       username: '{{ .dynamicsecret.username }}'
       password: '{{ .dynamicsecret.password }}'
-    type: Opaque
+    # type: Opaque
     labels:
       app: test-label
     annotations:

--- a/test/vaultsecret/vaultsecret-randomsecret-typed.yaml
+++ b/test/vaultsecret/vaultsecret-randomsecret-typed.yaml
@@ -1,0 +1,20 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: randomsecret-typed
+spec:
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: randomsecret
+      path: test-vault-config-operator/kv/randomsecret-password
+  output:
+    name: randomsecret-typed
+    stringData:
+      username: vault-user
+      password: '{{ .randomsecret.password }}'
+    type: kubernetes.io/basic-auth
+  refreshPeriod: 3m0s

--- a/test/vaultsecret/vaultsecret-randomsecret.yaml
+++ b/test/vaultsecret/vaultsecret-randomsecret.yaml
@@ -23,7 +23,7 @@ spec:
     stringData:
       password: '{{ .randomsecret.password }}'
       anotherpassword: '{{ .anotherrandomsecret.password }}'
-    type: Opaque
+    # type: Opaque
     labels:
       app: test-vault-config-operator
     annotations:


### PR DESCRIPTION
This makes the VaultSecret spec.output.type Optional and updated tests to confirm defaulting behavior.
Issue #363 